### PR TITLE
波紋エフェクトと波打ちエフェクトのコントロール表示順を統一

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Ripple/RippleEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Ripple/RippleEffect.cs
@@ -20,13 +20,13 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Ripple
         [AnimationSlider("F1", "px", -500d, 500d)]
         public Animation Y { get; } = new Animation(0, -99999, 99999);
 
-        [Display(GroupName = nameof(Texts.RippleGroupName), Name = nameof(Texts.RippleEffectWaveLengthName), Description = nameof(Texts.RippleEffectWaveLengthDesc), Order = 100, ResourceType = typeof(Texts))]
-        [AnimationSlider("F1", "px", -100d, 100d)]
-        public Animation WaveLength { get; } = new Animation(60, -99999, 99999);
-
         [Display(GroupName = nameof(Texts.RippleGroupName), Name = nameof(Texts.RippleEffectAmplitudeName), Description = nameof(Texts.RippleEffectAmplitudeDesc), Order = 100, ResourceType = typeof(Texts))]
         [AnimationSlider("F1", "px", -100d, 100d)]
         public Animation Amplitude { get; } = new Animation(15, -99999, 99999);
+
+        [Display(GroupName = nameof(Texts.RippleGroupName), Name = nameof(Texts.RippleEffectWaveLengthName), Description = nameof(Texts.RippleEffectWaveLengthDesc), Order = 100, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", -100d, 100d)]
+        public Animation WaveLength { get; } = new Animation(60, -99999, 99999);
 
         [Display(GroupName = nameof(Texts.RippleGroupName), Name = nameof(Texts.RippleEffectPeriodName), Description = nameof(Texts.RippleEffectPeriodDesc), Order = 100, ResourceType = typeof(Texts))]
         [AnimationSlider("F2", nameof(Texts.SecUnit), -1d, 1d, ResourceType = typeof(Texts))]
@@ -61,8 +61,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Ripple
         [
             X,
             Y,
-            WaveLength,
             Amplitude,
+            WaveLength,
             Period
         ];
     }


### PR DESCRIPTION
波紋エフェクトの振幅と波長コントロールの表示順を入れ替えました。
このことにより、振幅、波長、周期のコントロールの表示順が波打ちエフェクトと統一されます。