### PR TITLE
音量取得映像エフェクトを追加

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/FileAudioSourceReader.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/FileAudioSourceReader.cs
@@ -1,0 +1,56 @@
+﻿using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.FileSource;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater.AudioSourceReader
+{
+    public class FileAudioSourceReader(FileAudioSourceReaderParameter item) : AudioSourceReaderBase
+    {
+        IAudioFileSource? source;
+        bool isFirst = true;
+        string file = "";
+
+        public override (int, int, float[]) Read(TimelineItemSourceDescription timelineItemSourceDescription, int smooth, TimeSpan playback)
+        {
+            var fps = timelineItemSourceDescription.FPS;
+            var file = item.File;
+            bool isSourceChanged = isFirst || this.file != file;
+
+            if (isSourceChanged)
+            {
+                if (source is not null)
+                {
+                    disposer.RemoveAndDispose(ref source);
+                    source = null;
+                }
+                source = AudioFileSourceFactory.Create(file, 0);
+                if (source is not null)
+                    disposer.Collect(source);
+            }
+
+            int samplingRate = source is null ? 0 : source.Hz;
+            TimeSpan position = timelineItemSourceDescription.ItemPosition.Time + playback - TimeSpan.FromSeconds(1 + smooth).Divide(fps * 2);
+            TimeSpan headCut, cutPosition;
+            if (position < TimeSpan.Zero)
+            {
+                headCut = -position;
+                cutPosition = TimeSpan.Zero;
+            }
+            else
+            {
+                headCut = TimeSpan.Zero;
+                cutPosition = position;
+            }
+            int count = samplingRate * smooth / fps * 2;
+            int cutCount = count - (int)(samplingRate * headCut.TotalSeconds) * 2;
+            float[] destBuffer = new float[cutCount];
+
+            source?.Seek(cutPosition);
+            int size = source?.Read(destBuffer, 0, cutCount) ?? 0;
+
+            isFirst = false;
+            this.file = file;
+
+            return (size, count , destBuffer);
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/FileAudioSourceReader.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/FileAudioSourceReader.cs
@@ -18,16 +18,13 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Ca
             if (isSourceChanged)
             {
                 if (source is not null)
-                {
                     disposer.RemoveAndDispose(ref source);
-                    source = null;
-                }
                 source = AudioFileSourceFactory.Create(file, 0);
                 if (source is not null)
                     disposer.Collect(source);
             }
 
-            int samplingRate = source is null ? 0 : source.Hz;
+            int samplingRate = source?.Hz ?? 0;
             TimeSpan position = timelineItemSourceDescription.ItemPosition.Time + playback - TimeSpan.FromSeconds(1 + smooth).Divide(fps * 2);
             TimeSpan headCut, cutPosition;
             if (position < TimeSpan.Zero)

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/FileAudioSourceReaderParameter.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/FileAudioSourceReaderParameter.cs
@@ -10,7 +10,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Ca
         [Display(Name = nameof(Texts.File), Description = nameof(Texts.File), ResourceType = typeof(Texts))]
         [FileSelector(Settings.FileGroupType.AudioItem)]
         public string File { get => file; set => Set(ref file, value); }
-        string file = "";
+        string file = string.Empty;
 
         public FileAudioSourceReaderParameter() : base() { }
 
@@ -45,7 +45,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Ca
 
         public IEnumerable<string> GetFiles()
         {
-            if (File != "")
+            if (!string.IsNullOrEmpty(File))
                 yield return File;
         }
 
@@ -58,7 +58,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Ca
         private class SharedData
         {
             public string File { get => file; set => file = value; }
-            string file = "";
+            string file = string.Empty;
 
             public SharedData(FileAudioSourceReaderParameter param)
             {

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/FileAudioSourceReaderParameter.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/FileAudioSourceReaderParameter.cs
@@ -1,0 +1,74 @@
+﻿using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Project;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater.AudioSourceReader
+{
+    public class FileAudioSourceReaderParameter : AudioSourceReaderParameterBase, IFileItem
+    {
+        [Display(Name = nameof(Texts.File), Description = nameof(Texts.File), ResourceType = typeof(Texts))]
+        [FileSelector(Settings.FileGroupType.AudioItem)]
+        public string File { get => file; set => Set(ref file, value); }
+        string file = "";
+
+        public FileAudioSourceReaderParameter() : base() { }
+
+        public FileAudioSourceReaderParameter(SharedDataStore? sharedDataStore = null) : base(sharedDataStore) { }
+
+        public override AudioSourceReaderBase CreateReader()
+        {
+            return new FileAudioSourceReader(this);
+        }
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [];
+
+        protected override void LoadSharedData(SharedDataStore store)
+        {
+            var sharedData = store.Load<SharedData>();
+            if (sharedData is null)
+                return;
+
+            sharedData.CopyTo(this);
+        }
+
+        protected override void SaveSharedData(SharedDataStore store)
+        {
+            store.Save(new SharedData(this));
+        }
+
+        public IEnumerable<TimelineResource> GetResources()
+        {
+            if (TimelineResource.TryParseFromPath(File, TimelineResourceType.Audio, out var resource))
+                yield return resource;
+        }
+
+        public IEnumerable<string> GetFiles()
+        {
+            if (File != "")
+                yield return File;
+        }
+
+        public void ReplaceFile(string from, string to)
+        {
+            if (from == File)
+                File = to;
+        }
+
+        private class SharedData
+        {
+            public string File { get => file; set => file = value; }
+            string file = "";
+
+            public SharedData(FileAudioSourceReaderParameter param)
+            {
+                File = param.File;
+            }
+
+            public void CopyTo(FileAudioSourceReaderParameter param)
+            {
+                param.File = file;
+            }
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/SceneAudioSourceReader.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/SceneAudioSourceReader.cs
@@ -18,10 +18,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Ca
             if (isSourceChanged)
             {
                 if (source is not null)
-                {
                     disposer.RemoveAndDispose(ref source);
-                    source = null;
-                }
                 timelineItemSourceDescription.Scenes.FirstOrDefault(x => x.ID == sceneId)?.TryCreateAudioSource(out source);
                 if (source is not null)
                     disposer.Collect(source);

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/SceneAudioSourceReader.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/SceneAudioSourceReader.cs
@@ -1,0 +1,56 @@
+﻿using YukkuriMovieMaker.Player.Audio.Effects;
+using YukkuriMovieMaker.Player.Video;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater.AudioSourceReader
+{
+    public class SceneAudioSourceReader(SceneAudioSourceReaderParameter item) : AudioSourceReaderBase
+    {
+        IAudioStream? source;
+        bool isFirst = true;
+        Guid sceneId;
+
+        public override (int, int, float[]) Read(TimelineItemSourceDescription timelineItemSourceDescription, int smooth, TimeSpan playback)
+        {
+            var fps = timelineItemSourceDescription.FPS;
+            var sceneId = item.SceneId;
+            bool isSourceChanged = isFirst || this.sceneId != sceneId;
+
+            if (isSourceChanged)
+            {
+                if (source is not null)
+                {
+                    disposer.RemoveAndDispose(ref source);
+                    source = null;
+                }
+                timelineItemSourceDescription.Scenes.FirstOrDefault(x => x.ID == sceneId)?.TryCreateAudioSource(out source);
+                if (source is not null)
+                    disposer.Collect(source);
+            }
+
+            int samplingRate = source is null ? 0 : source.Hz;
+            TimeSpan position = timelineItemSourceDescription.ItemPosition.Time + playback - TimeSpan.FromSeconds(1 + smooth).Divide(fps * 2);
+            TimeSpan headCut, cutPosition;
+            if (position < TimeSpan.Zero)
+            {
+                headCut = -position;
+                cutPosition = TimeSpan.Zero;
+            }
+            else
+            {
+                headCut = TimeSpan.Zero;
+                cutPosition = position;
+            }
+            int count = samplingRate * smooth / fps * 2;
+            int cutCount = count - (int)(samplingRate * headCut.TotalSeconds) * 2;
+            float[] destBuffer = new float[cutCount];
+
+            source?.Seek(cutPosition);
+            int size = source?.Read(destBuffer, 0, cutCount) ?? 0;
+
+            isFirst = false;
+            this.sceneId = sceneId;
+
+            return (size, count, destBuffer);
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/SceneAudioSourceReaderParameter.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/SceneAudioSourceReaderParameter.cs
@@ -1,0 +1,56 @@
+﻿using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Project;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater.AudioSourceReader
+{
+    public class SceneAudioSourceReaderParameter : AudioSourceReaderParameterBase
+    {
+        [Display(Name = nameof(Texts.Scene), Description = nameof(Texts.Scene), ResourceType = typeof(Texts))]
+        [SceneComboBox]
+        public Guid SceneId { get => sceneId; set => Set(ref sceneId, value); }
+        Guid sceneId = Guid.Empty;
+
+        public SceneAudioSourceReaderParameter() { }
+
+        public SceneAudioSourceReaderParameter(SharedDataStore? store = null) : base(store) { }
+
+        public override AudioSourceReaderBase CreateReader()
+        {
+            return new SceneAudioSourceReader(this);
+        }
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [];
+
+        protected override void LoadSharedData(SharedDataStore store)
+        {
+            var sharedData = store.Load<SharedData>();
+            if (sharedData is null)
+                return;
+
+            sharedData.CopyTo(this);
+        }
+
+        protected override void SaveSharedData(SharedDataStore store)
+        {
+            store.Save(new SharedData(this));
+        }
+
+        private class SharedData
+        {
+            public Guid SceneId { get => sceneId; set => sceneId = value; }
+            Guid sceneId = Guid.Empty;
+
+            public SharedData(SceneAudioSourceReaderParameter param)
+            {
+                SceneId = param.SceneId;
+            }
+
+            public void CopyTo(SceneAudioSourceReaderParameter param)
+            {
+                param.SceneId = SceneId;
+            }
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/TimelineAudioSourceReader.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/TimelineAudioSourceReader.cs
@@ -1,0 +1,56 @@
+﻿using YukkuriMovieMaker.Player.Audio.Effects;
+using YukkuriMovieMaker.Player.Video;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater.AudioSourceReader
+{
+    public class TimelineAudioSourceReader() : AudioSourceReaderBase
+    {
+        IAudioStream? source;
+        bool isFirst = true;
+        Guid sceneId;
+
+        public override (int, int, float[]) Read(TimelineItemSourceDescription timelineItemSourceDescription, int smooth, TimeSpan playback)
+        {
+            var fps = timelineItemSourceDescription.FPS;
+            var sceneId = timelineItemSourceDescription.SceneId;
+            bool isSourceChanged = isFirst || this.sceneId != sceneId;
+
+            if (isSourceChanged)
+            {
+                if (source is not null)
+                {
+                    disposer.RemoveAndDispose(ref source);
+                    source = null;
+                }
+                timelineItemSourceDescription.Scenes.FirstOrDefault(x => x.ID == sceneId)?.TryCreateAudioSource(out source);
+                if (source is not null)
+                    disposer.Collect(source);
+            }
+
+            int samplingRate = source is null ? 0 : source.Hz;
+            TimeSpan position = timelineItemSourceDescription.TimelinePosition.Time + playback - TimeSpan.FromSeconds(1 + smooth).Divide(fps * 2);
+            TimeSpan headCut, cutPosition;
+            if (position < TimeSpan.Zero)
+            {
+                headCut = -position;
+                cutPosition = TimeSpan.Zero;
+            }
+            else
+            {
+                headCut = TimeSpan.Zero;
+                cutPosition = position;
+            }
+            int count = samplingRate * smooth / fps * 2;
+            int cutCount = count - (int)(samplingRate * headCut.TotalSeconds) * 2;
+            float[] destBuffer = new float[cutCount];
+
+            source?.Seek(cutPosition);
+            int size = source?.Read(destBuffer, 0, cutCount) ?? 0;
+
+            isFirst = false;
+            this.sceneId = sceneId;
+
+            return (size, count, destBuffer);
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/TimelineAudioSourceReader.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/TimelineAudioSourceReader.cs
@@ -18,16 +18,13 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Ca
             if (isSourceChanged)
             {
                 if (source is not null)
-                {
                     disposer.RemoveAndDispose(ref source);
-                    source = null;
-                }
                 timelineItemSourceDescription.Scenes.FirstOrDefault(x => x.ID == sceneId)?.TryCreateAudioSource(out source);
                 if (source is not null)
                     disposer.Collect(source);
             }
 
-            int samplingRate = source is null ? 0 : source.Hz;
+            int samplingRate = source?.Hz ?? 0;
             TimeSpan position = timelineItemSourceDescription.TimelinePosition.Time + playback - TimeSpan.FromSeconds(1 + smooth).Divide(fps * 2);
             TimeSpan headCut, cutPosition;
             if (position < TimeSpan.Zero)

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/TimelineAudioSourceReaderParameter.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReader/TimelineAudioSourceReaderParameter.cs
@@ -1,0 +1,31 @@
+﻿using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Project;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater.AudioSourceReader
+{
+    public class TimelineAudioSourceReaderParameter : AudioSourceReaderParameterBase
+    {
+        public TimelineAudioSourceReaderParameter() : base()
+        {
+        }
+
+        public TimelineAudioSourceReaderParameter(SharedDataStore? store = null) : base(store)
+        { 
+        }
+
+        public override AudioSourceReaderBase CreateReader()
+        {
+            return new TimelineAudioSourceReader();
+        }
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [];
+
+        protected override void LoadSharedData(SharedDataStore store) 
+        {
+        }
+
+        protected override void SaveSharedData(SharedDataStore store) 
+        { 
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReaderBase.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReaderBase.cs
@@ -1,0 +1,33 @@
+﻿using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater
+{
+    public abstract class AudioSourceReaderBase : IDisposable
+    {
+        protected readonly DisposeCollector disposer = new();
+
+        public abstract (int, int, float[]) Read(TimelineItemSourceDescription timelineItemSourceDescription, int smooth, TimeSpan playback);
+
+        #region IDisposable Support
+        private bool disposedValue;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    disposer.Dispose();
+                }
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+        #endregion
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReaderParameterBase.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceReaderParameterBase.cs
@@ -1,0 +1,13 @@
+﻿using YukkuriMovieMaker.Project;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater
+{
+    public abstract class AudioSourceReaderParameterBase : SharedParameterBase
+    {
+        public AudioSourceReaderParameterBase() : base() { }
+
+        public AudioSourceReaderParameterBase(SharedDataStore? store = null) : base(store) { }
+
+        public abstract AudioSourceReaderBase CreateReader();
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceType.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceType.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater
+{
+    public enum AudioSourceType
+    {
+        [Display(Name = nameof(Texts.AudioSourceTypeFile), Description = nameof(Texts.AudioSourceTypeFile), ResourceType = typeof(Texts))]
+        File,
+        [Display(Name = nameof(Texts.AudioSourceTypeScene), Description = nameof(Texts.AudioSourceTypeScene), ResourceType = typeof(Texts))]
+        Scene,
+        [Display(Name = nameof(Texts.AudioSourceTypeTimeline), Description = nameof(Texts.AudioSourceTypeTimeline), ResourceType = typeof(Texts))]
+        Timeline,
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceTypeEx.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioSourceTypeEx.cs
@@ -1,0 +1,20 @@
+﻿using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater.AudioSourceReader;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater
+{
+    public static class AudioSourceTypeEx
+    {
+        public static AudioSourceReaderParameterBase Convert(this AudioSourceType type, AudioSourceReaderParameterBase current)
+        {
+            var store = current.GetSharedData();
+            AudioSourceReaderParameterBase param = type switch
+            {
+                AudioSourceType.File => new FileAudioSourceReaderParameter(store),
+                AudioSourceType.Scene => new SceneAudioSourceReaderParameter(store),
+                AudioSourceType.Timeline => new TimelineAudioSourceReaderParameter(store),
+                _ => throw new ArgumentOutOfRangeException(nameof(type)),
+            };
+            return param.GetType() != current.GetType() ? param : current;
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioVolumeCalculater.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioVolumeCalculater.cs
@@ -1,0 +1,80 @@
+﻿using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater.AudioSourceReader;
+using YukkuriMovieMaker.Project;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater
+{
+    public class AudioVolumeCalculater : Animatable, IFileItem
+    {
+        [Display(Name = nameof(Texts.AudioSourceType), Description = nameof(Texts.AudioSourceType), ResourceType = typeof(Texts))]
+        [EnumComboBox]
+        public AudioSourceType SourceType { get => sourceType; set => Set(ref sourceType, value); }
+        AudioSourceType sourceType = AudioSourceType.Timeline;
+
+        [Display(AutoGenerateField = true)]
+        public AudioSourceReaderParameterBase SourceParameter { get => sourceParameter; set => Set(ref sourceParameter, value); }
+        AudioSourceReaderParameterBase sourceParameter = new TimelineAudioSourceReaderParameter();
+
+        [Display(Name = nameof(Texts.Power), Description = nameof(Texts.Power), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 200)]
+        public Animation Power { get; } = new Animation(100, 0, 99999);
+
+        [Display(Name = nameof(Texts.Smooth), Description = nameof(Texts.Smooth), ResourceType = typeof(Texts))]
+        [AnimationSlider("F0", "", 1, 10)]
+        public Animation Smooth { get; } = new Animation(4, 1, 10);
+
+        [Display(Name = nameof(Texts.Playback), Description = nameof(Texts.Playback), ResourceType = typeof(Texts))]
+        [TimeSpanEditor]
+        [TimeSpanDefaultValue("00:00:00.00")]
+        public TimeSpan Playback { get => playback; set => Set(ref playback, value); }
+        TimeSpan playback = TimeSpan.Zero;
+
+        public AudioVolumeCalculaterSource CreateSource() => new(this);
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [SourceParameter, Power, Smooth];
+
+        public override void BeginEdit()
+        {
+            base.BeginEdit();
+        }
+
+        public override ValueTask EndEditAsync()
+        {
+            SourceParameter = SourceType.Convert(SourceParameter);
+
+            return base.EndEditAsync();
+        }
+
+        public IEnumerable<TimelineResource> GetResources()
+        {
+            if(SourceParameter is IResourceItem parameterResourceItem)
+            {
+                foreach(var resource in parameterResourceItem.GetResources())
+                {
+                    yield return resource;
+                }
+            }
+        }
+
+        public IEnumerable<string> GetFiles()
+        {
+            if (SourceParameter is IFileItem parameterFileItem)
+            {
+                foreach (var file in parameterFileItem.GetFiles())
+                {
+                    yield return file;
+                }
+            }
+        }
+
+        public void ReplaceFile(string from, string to)
+        {
+            if (SourceParameter is IFileItem parameterFileItem)
+            {
+                parameterFileItem.ReplaceFile(from, to);
+            }
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioVolumeCalculaterSource.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/AudioVolumeCalculaterSource.cs
@@ -1,0 +1,71 @@
+﻿using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater
+{
+    public class AudioVolumeCalculaterSource(AudioVolumeCalculater item) : IDisposable
+    {
+        readonly DisposeCollector disposer = new();
+
+        AudioSourceReaderBase? reader;
+        bool isFirst = true;
+        AudioSourceType sourceType;
+
+        public double GetVolume(TimelineItemSourceDescription timelineItemSourceDescription)
+        {
+            var frame = timelineItemSourceDescription.ItemPosition.Frame;
+            var length = timelineItemSourceDescription.ItemDuration.Frame;
+            var fps = timelineItemSourceDescription.FPS;
+
+            var sourceType = item.SourceType;
+            var sourceParameter = item.SourceParameter;
+            var power = item.Power.GetValue(frame, length, fps) / 100;
+            var smooth = (int)item.Smooth.GetValue(frame, length, fps);
+            var playback = item.Playback;
+
+            if (isFirst || this.sourceType != sourceType)
+            {
+                if (reader is not null)
+                {
+                    disposer.RemoveAndDispose(ref reader);
+                    reader = null;
+                }
+                reader = sourceParameter.CreateReader();
+                disposer.Collect(reader);
+            }
+
+            (int size, int count, float[] destBuffer) = reader?.Read(timelineItemSourceDescription, smooth, playback) ?? (0, 0, []);
+
+            isFirst = false;
+            this.sourceType = sourceType;
+
+            if (count == 0)
+                return 0;
+            double volume = 0;
+            for (int i = 0; i < size; i++)
+                volume += Math.Min(1, destBuffer[i] * power * destBuffer[i] * power);
+            return Math.Sqrt(volume / count);
+        }
+
+        #region IDisposable Support
+        private bool disposedValue;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    disposer.Dispose();
+                }
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+        #endregion
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.ar-sa.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.ar-sa.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ar-sa</value></data>
+<data name="AudioSourceType" xml:space="preserve"><value>الصوت</value></data>
+<data name="Power" xml:space="preserve"><value>مستوى الصوت</value></data>
+<data name="Smooth" xml:space="preserve"><value>نعومة</value></data>
+<data name="Playback" xml:space="preserve"><value>موقع التشغيل</value></data>
+<data name="AudioSourceTypeFile" xml:space="preserve"><value>ملف</value></data>
+<data name="AudioSourceTypeScene" xml:space="preserve"><value>مشهد</value></data>
+<data name="AudioSourceTypeTimeline" xml:space="preserve"><value>الجدول الزمني</value></data>
+<data name="File" xml:space="preserve"><value>ملف</value></data>
+<data name="Scene" xml:space="preserve"><value>مشهد</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.cs
@@ -1,0 +1,9 @@
+﻿using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.csv
@@ -1,0 +1,10 @@
+﻿Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+AudioSourceType,,音声,Audio,音频,音訊,오디오,Audio,الصوت,Audio
+Power,,音量,Volume,音量,音量,볼륨,Volumen,مستوى الصوت,Volume
+Smooth,,なめらかさ,Smoothness,平滑度,平滑度,부드러움,Suavidad,نعومة,Kelembutan
+Playback,,再生位置,Playback Position,播放位置,播放位置,재생 위치,Posición de reproducción,موقع التشغيل,Posisi Pemutaran
+AudioSourceTypeFile,,ファイル,File,文件,文件,파일,Archivo,ملف,Berkas
+AudioSourceTypeScene,,シーン,Scene,场景,場景,장면,Escena,مشهد,Adegan
+AudioSourceTypeTimeline,,タイムライン,Timeline,时间轴,時間軸,타임라인,Línea de tiempo,الجدول الزمني,Garis Waktu
+File,,ファイル,File,文件,文件,파일,Archivo,ملف,Berkas
+Scene,,シーン,Scene,场景,場景,장면,Escena,مشهد,Adegan

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.en-us.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.en-us.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>en-us</value></data>
+<data name="AudioSourceType" xml:space="preserve"><value>Audio</value></data>
+<data name="Power" xml:space="preserve"><value>Volume</value></data>
+<data name="Smooth" xml:space="preserve"><value>Smoothness</value></data>
+<data name="Playback" xml:space="preserve"><value>Playback Position</value></data>
+<data name="AudioSourceTypeFile" xml:space="preserve"><value>File</value></data>
+<data name="AudioSourceTypeScene" xml:space="preserve"><value>Scene</value></data>
+<data name="AudioSourceTypeTimeline" xml:space="preserve"><value>Timeline</value></data>
+<data name="File" xml:space="preserve"><value>File</value></data>
+<data name="Scene" xml:space="preserve"><value>Scene</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.es-es.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.es-es.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>es-es</value></data>
+<data name="AudioSourceType" xml:space="preserve"><value>Audio</value></data>
+<data name="Power" xml:space="preserve"><value>Volumen</value></data>
+<data name="Smooth" xml:space="preserve"><value>Suavidad</value></data>
+<data name="Playback" xml:space="preserve"><value>Posición de reproducción</value></data>
+<data name="AudioSourceTypeFile" xml:space="preserve"><value>Archivo</value></data>
+<data name="AudioSourceTypeScene" xml:space="preserve"><value>Escena</value></data>
+<data name="AudioSourceTypeTimeline" xml:space="preserve"><value>Línea de tiempo</value></data>
+<data name="File" xml:space="preserve"><value>Archivo</value></data>
+<data name="Scene" xml:space="preserve"><value>Escena</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.id-id.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.id-id.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>id-id</value></data>
+<data name="AudioSourceType" xml:space="preserve"><value>Audio</value></data>
+<data name="Power" xml:space="preserve"><value>Volume</value></data>
+<data name="Smooth" xml:space="preserve"><value>Kelembutan</value></data>
+<data name="Playback" xml:space="preserve"><value>Posisi Pemutaran</value></data>
+<data name="AudioSourceTypeFile" xml:space="preserve"><value>Berkas</value></data>
+<data name="AudioSourceTypeScene" xml:space="preserve"><value>Adegan</value></data>
+<data name="AudioSourceTypeTimeline" xml:space="preserve"><value>Garis Waktu</value></data>
+<data name="File" xml:space="preserve"><value>Berkas</value></data>
+<data name="Scene" xml:space="preserve"><value>Adegan</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.ko-kr.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.ko-kr.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ko-kr</value></data>
+<data name="AudioSourceType" xml:space="preserve"><value>오디오</value></data>
+<data name="Power" xml:space="preserve"><value>볼륨</value></data>
+<data name="Smooth" xml:space="preserve"><value>부드러움</value></data>
+<data name="Playback" xml:space="preserve"><value>재생 위치</value></data>
+<data name="AudioSourceTypeFile" xml:space="preserve"><value>파일</value></data>
+<data name="AudioSourceTypeScene" xml:space="preserve"><value>장면</value></data>
+<data name="AudioSourceTypeTimeline" xml:space="preserve"><value>타임라인</value></data>
+<data name="File" xml:space="preserve"><value>파일</value></data>
+<data name="Scene" xml:space="preserve"><value>장면</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ja-jp</value></data>
+<data name="AudioSourceType" xml:space="preserve"><value>音声</value></data>
+<data name="Power" xml:space="preserve"><value>音量</value></data>
+<data name="Smooth" xml:space="preserve"><value>なめらかさ</value></data>
+<data name="Playback" xml:space="preserve"><value>再生位置</value></data>
+<data name="AudioSourceTypeFile" xml:space="preserve"><value>ファイル</value></data>
+<data name="AudioSourceTypeScene" xml:space="preserve"><value>シーン</value></data>
+<data name="AudioSourceTypeTimeline" xml:space="preserve"><value>タイムライン</value></data>
+<data name="File" xml:space="preserve"><value>ファイル</value></data>
+<data name="Scene" xml:space="preserve"><value>シーン</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.zh-cn.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.zh-cn.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-cn</value></data>
+<data name="AudioSourceType" xml:space="preserve"><value>音频</value></data>
+<data name="Power" xml:space="preserve"><value>音量</value></data>
+<data name="Smooth" xml:space="preserve"><value>平滑度</value></data>
+<data name="Playback" xml:space="preserve"><value>播放位置</value></data>
+<data name="AudioSourceTypeFile" xml:space="preserve"><value>文件</value></data>
+<data name="AudioSourceTypeScene" xml:space="preserve"><value>场景</value></data>
+<data name="AudioSourceTypeTimeline" xml:space="preserve"><value>时间轴</value></data>
+<data name="File" xml:space="preserve"><value>文件</value></data>
+<data name="Scene" xml:space="preserve"><value>场景</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.zh-tw.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/Calculater/Texts.zh-tw.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-tw</value></data>
+<data name="AudioSourceType" xml:space="preserve"><value>音訊</value></data>
+<data name="Power" xml:space="preserve"><value>音量</value></data>
+<data name="Smooth" xml:space="preserve"><value>平滑度</value></data>
+<data name="Playback" xml:space="preserve"><value>播放位置</value></data>
+<data name="AudioSourceTypeFile" xml:space="preserve"><value>文件</value></data>
+<data name="AudioSourceTypeScene" xml:space="preserve"><value>場景</value></data>
+<data name="AudioSourceTypeTimeline" xml:space="preserve"><value>時間軸</value></data>
+<data name="File" xml:space="preserve"><value>文件</value></data>
+<data name="Scene" xml:space="preserve"><value>場景</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/AudioVolumeVideoEffectBase.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/AudioVolumeVideoEffectBase.cs
@@ -1,0 +1,38 @@
+﻿using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater;
+using YukkuriMovieMaker.Plugin.Effects;
+using YukkuriMovieMaker.Project;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase
+{
+    public abstract class AudioVolumeVideoEffectBase : VideoEffectBase, IFileItem
+    {
+        [Display(GroupName = nameof(Texts.AudioSourceGroup), AutoGenerateField = true, ResourceType = typeof(Texts))]
+        public AudioVolumeCalculater Calculater { get; } = new AudioVolumeCalculater();
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [Calculater];
+
+        public override IEnumerable<string> GetFiles()
+        {
+            foreach (var file in base.GetFiles())
+                yield return file;
+            foreach (var file in Calculater.GetFiles())
+                yield return file;
+        }
+
+        public override void ReplaceFile(string from, string to)
+        {
+            base.ReplaceFile(from, to);
+            Calculater.ReplaceFile(from, to);
+        }
+
+        public override IEnumerable<TimelineResource> GetResources()
+        {
+            foreach (var resource in base.GetResources())
+                yield return resource;
+            foreach (var resource in Calculater.GetResources())
+                yield return resource;
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/AudioVolumeVideoEffectProcessorBase.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/AudioVolumeVideoEffectProcessorBase.cs
@@ -1,0 +1,25 @@
+﻿using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Player.Video.Effects;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Calculater;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase
+{
+    public abstract class AudioVolumeVideoEffectProcessorBase : VideoEffectProcessorBase
+    {
+        protected readonly AudioVolumeCalculaterSource calculaterSource;
+
+        public AudioVolumeVideoEffectProcessorBase(IGraphicsDevicesAndContext devices, AudioVolumeVideoEffectBase item) : base(devices)
+        {
+            calculaterSource = item.Calculater.CreateSource();
+            disposer.Collect(calculaterSource);
+        }
+
+        public override DrawDescription Update(EffectDescription effectDescription)
+        {
+            return Update(effectDescription, calculaterSource.GetVolume(effectDescription));
+        }
+
+        public abstract DrawDescription Update(EffectDescription effectDescription, double audioVolume);
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/AudioVolumeVideoEffectProcessorBase.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/AudioVolumeVideoEffectProcessorBase.cs
@@ -8,7 +8,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.Ef
     public abstract class AudioVolumeVideoEffectProcessorBase : VideoEffectProcessorBase
     {
         protected readonly AudioVolumeCalculaterSource calculaterSource;
-
+        
         public AudioVolumeVideoEffectProcessorBase(IGraphicsDevicesAndContext devices, AudioVolumeVideoEffectBase item) : base(devices)
         {
             calculaterSource = item.Calculater.CreateSource();

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.ar-sa.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.ar-sa.resx
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ar-sa</value></data>
+<data name="AudioSourceGroup" xml:space="preserve"><value>مصدر الصوت</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.cs
@@ -1,0 +1,9 @@
+﻿using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.csv
@@ -1,0 +1,2 @@
+﻿Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+AudioSourceGroup,,音源,Sound Source,声音来源,聲音來源,음원,Fuente de sonido,مصدر الصوت,Sumber Suara

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.en-us.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.en-us.resx
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>en-us</value></data>
+<data name="AudioSourceGroup" xml:space="preserve"><value>Sound Source</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.es-es.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.es-es.resx
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>es-es</value></data>
+<data name="AudioSourceGroup" xml:space="preserve"><value>Fuente de sonido</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.id-id.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.id-id.resx
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>id-id</value></data>
+<data name="AudioSourceGroup" xml:space="preserve"><value>Sumber Suara</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.ko-kr.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.ko-kr.resx
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ko-kr</value></data>
+<data name="AudioSourceGroup" xml:space="preserve"><value>음원</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.resx
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ja-jp</value></data>
+<data name="AudioSourceGroup" xml:space="preserve"><value>音源</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.zh-cn.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.zh-cn.resx
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-cn</value></data>
+<data name="AudioSourceGroup" xml:space="preserve"><value>声音来源</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.zh-tw.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Commons/EffectBase/Texts.zh-tw.resx
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-tw</value></data>
+<data name="AudioSourceGroup" xml:space="preserve"><value>聲音來源</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/AudioVolumeMoveEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/AudioVolumeMoveEffect.cs
@@ -1,0 +1,40 @@
+﻿using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase;
+using YukkuriMovieMaker.Plugin.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Move
+{
+    [VideoEffect(nameof(Texts.AudioVolumeMoveEffect), [VideoEffectCategories.Animation], ["描画位置", "座標", "audio volume move"], IsAviUtlSupported = false, IsEffectItemSupported = false, ResourceType = typeof(Texts))]
+    internal class AudioVolumeMoveEffect : AudioVolumeVideoEffectBase
+    {
+        public override string Label => $"{Texts.AudioVolumeMoveEffect} X{X.GetValue(0, 1, 30):F0}px, Y{Y.GetValue(0, 1, 30):F0}px, Z{Z.GetValue(0, 1, 30):F0}px";
+
+        [Display(GroupName = nameof(Texts.AudioVolumeMoveEffect), Name = nameof(Texts.X), Description = nameof(Texts.XDesc), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", -500, 500)]
+        public Animation X { get; } = new Animation(0, -99999, 99999);
+
+        [Display(GroupName = nameof(Texts.AudioVolumeMoveEffect), Name = nameof(Texts.Y), Description = nameof(Texts.YDesc), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", -500, 500)]
+        public Animation Y { get; } = new Animation(-100, -99999, 99999);
+
+        [Display(GroupName = nameof(Texts.AudioVolumeMoveEffect), Name = nameof(Texts.Z), Description = nameof(Texts.ZDesc), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", -500, 500)]
+        public Animation Z { get; } = new Animation(0, -99999, 99999);
+
+        public override IEnumerable<string> CreateExoVideoFilters(int keyFrameIndex, ExoOutputDescription exoOutputDescription)
+        {
+            return [];
+        }
+
+        public override IVideoEffectProcessor CreateVideoEffect(IGraphicsDevicesAndContext devices)
+        {
+            return new AudioVolumeMoveEffectProcessor(devices, this);
+        }
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [X, Y, Z, ..base.GetAnimatables()];
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/AudioVolumeMoveEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/AudioVolumeMoveEffectProcessor.cs
@@ -1,0 +1,39 @@
+﻿using System.Numerics;
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Move
+{
+    internal class AudioVolumeMoveEffectProcessor(IGraphicsDevicesAndContext devices, AudioVolumeMoveEffect item) : AudioVolumeVideoEffectProcessorBase(devices, item)
+    {
+        public override DrawDescription Update(EffectDescription effectDescription, double audioVolume)
+        {
+            var frame = effectDescription.ItemPosition.Frame;
+            var length = effectDescription.ItemDuration.Frame;
+            var fps = effectDescription.FPS;
+
+            var x = (float)(item.X.GetValue(frame, length, fps) * audioVolume);
+            var y = (float)(item.Y.GetValue(frame, length, fps) * audioVolume);
+            var z = (float)(item.Z.GetValue(frame, length, fps) * audioVolume);
+
+            var drawDescription = effectDescription.DrawDescription;
+
+            return drawDescription with { Draw = drawDescription.Draw + new Vector3(x, y, z) };
+        }
+
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            return null;
+        }
+
+        protected override void setInput(ID2D1Image? input) 
+        {
+        }
+
+        protected override void ClearEffectChain() 
+        {
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.ar-sa.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.ar-sa.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ar-sa</value></data>
+<data name="AudioVolumeMoveEffect" xml:space="preserve"><value>التحرك حسب مستوى الصوت</value></data>
+<data name="X" xml:space="preserve"><value>X</value></data>
+<data name="XDesc" xml:space="preserve"><value>المسافة للتحرك في اتجاه المحور X</value></data>
+<data name="Y" xml:space="preserve"><value>Y</value></data>
+<data name="YDesc" xml:space="preserve"><value>المسافة للتحرك في اتجاه المحور Y</value></data>
+<data name="Z" xml:space="preserve"><value>Z</value></data>
+<data name="ZDesc" xml:space="preserve"><value>المسافة للتحرك في اتجاه المحور Z</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.cs
@@ -1,0 +1,9 @@
+﻿using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Move
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.csv
@@ -1,0 +1,8 @@
+﻿Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+AudioVolumeMoveEffect,,音量に合わせて移動,Move According to Volume,根据音量移动,根據音量移動,음량에 따라 이동,Mover según el volumen,التحرك حسب مستوى الصوت,Bergerak Sesuai Volume
+X,,X,X,X,X,X,X,X,X
+XDesc,,X軸方向に移動する距離,Distance to Move in X Direction,X轴移动距离,X軸移動距離,X축 이동 거리,Distancia a mover en la dirección X,المسافة للتحرك في اتجاه المحور X,Jarak Pergerakan ke Arah Sumbu X
+Y,,Y,Y,Y,Y,Y,Y,Y,Y
+YDesc,,Y軸方向に移動する距離,Distance to Move in Y Direction,Y轴移动距离,Y軸移動距離,Y축 이동 거리,Distancia a mover en la dirección Y,المسافة للتحرك في اتجاه المحور Y,Jarak Pergerakan ke Arah Sumbu Y
+Z,,Z,Z,Z,Z,Z,Z,Z,Z
+ZDesc,,Z軸方向に移動する距離,Distance to Move in Z Direction,Z轴移动距离,Z軸移動距離,Z축 이동 거리,Distancia a mover en la dirección Z,المسافة للتحرك في اتجاه المحور Z,Jarak Pergerakan ke Arah Sumbu Z

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.en-us.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.en-us.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>en-us</value></data>
+<data name="AudioVolumeMoveEffect" xml:space="preserve"><value>Move According to Volume</value></data>
+<data name="X" xml:space="preserve"><value>X</value></data>
+<data name="XDesc" xml:space="preserve"><value>Distance to Move in X Direction</value></data>
+<data name="Y" xml:space="preserve"><value>Y</value></data>
+<data name="YDesc" xml:space="preserve"><value>Distance to Move in Y Direction</value></data>
+<data name="Z" xml:space="preserve"><value>Z</value></data>
+<data name="ZDesc" xml:space="preserve"><value>Distance to Move in Z Direction</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.es-es.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.es-es.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>es-es</value></data>
+<data name="AudioVolumeMoveEffect" xml:space="preserve"><value>Mover según el volumen</value></data>
+<data name="X" xml:space="preserve"><value>X</value></data>
+<data name="XDesc" xml:space="preserve"><value>Distancia a mover en la dirección X</value></data>
+<data name="Y" xml:space="preserve"><value>Y</value></data>
+<data name="YDesc" xml:space="preserve"><value>Distancia a mover en la dirección Y</value></data>
+<data name="Z" xml:space="preserve"><value>Z</value></data>
+<data name="ZDesc" xml:space="preserve"><value>Distancia a mover en la dirección Z</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.id-id.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.id-id.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>id-id</value></data>
+<data name="AudioVolumeMoveEffect" xml:space="preserve"><value>Bergerak Sesuai Volume</value></data>
+<data name="X" xml:space="preserve"><value>X</value></data>
+<data name="XDesc" xml:space="preserve"><value>Jarak Pergerakan ke Arah Sumbu X</value></data>
+<data name="Y" xml:space="preserve"><value>Y</value></data>
+<data name="YDesc" xml:space="preserve"><value>Jarak Pergerakan ke Arah Sumbu Y</value></data>
+<data name="Z" xml:space="preserve"><value>Z</value></data>
+<data name="ZDesc" xml:space="preserve"><value>Jarak Pergerakan ke Arah Sumbu Z</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.ko-kr.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.ko-kr.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ko-kr</value></data>
+<data name="AudioVolumeMoveEffect" xml:space="preserve"><value>음량에 따라 이동</value></data>
+<data name="X" xml:space="preserve"><value>X</value></data>
+<data name="XDesc" xml:space="preserve"><value>X축 이동 거리</value></data>
+<data name="Y" xml:space="preserve"><value>Y</value></data>
+<data name="YDesc" xml:space="preserve"><value>Y축 이동 거리</value></data>
+<data name="Z" xml:space="preserve"><value>Z</value></data>
+<data name="ZDesc" xml:space="preserve"><value>Z축 이동 거리</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ja-jp</value></data>
+<data name="AudioVolumeMoveEffect" xml:space="preserve"><value>音量に合わせて移動</value></data>
+<data name="X" xml:space="preserve"><value>X</value></data>
+<data name="XDesc" xml:space="preserve"><value>X軸方向に移動する距離</value></data>
+<data name="Y" xml:space="preserve"><value>Y</value></data>
+<data name="YDesc" xml:space="preserve"><value>Y軸方向に移動する距離</value></data>
+<data name="Z" xml:space="preserve"><value>Z</value></data>
+<data name="ZDesc" xml:space="preserve"><value>Z軸方向に移動する距離</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.zh-cn.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.zh-cn.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-cn</value></data>
+<data name="AudioVolumeMoveEffect" xml:space="preserve"><value>根据音量移动</value></data>
+<data name="X" xml:space="preserve"><value>X</value></data>
+<data name="XDesc" xml:space="preserve"><value>X轴移动距离</value></data>
+<data name="Y" xml:space="preserve"><value>Y</value></data>
+<data name="YDesc" xml:space="preserve"><value>Y轴移动距离</value></data>
+<data name="Z" xml:space="preserve"><value>Z</value></data>
+<data name="ZDesc" xml:space="preserve"><value>Z轴移动距离</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.zh-tw.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Move/Texts.zh-tw.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-tw</value></data>
+<data name="AudioVolumeMoveEffect" xml:space="preserve"><value>根據音量移動</value></data>
+<data name="X" xml:space="preserve"><value>X</value></data>
+<data name="XDesc" xml:space="preserve"><value>X軸移動距離</value></data>
+<data name="Y" xml:space="preserve"><value>Y</value></data>
+<data name="YDesc" xml:space="preserve"><value>Y軸移動距離</value></data>
+<data name="Z" xml:space="preserve"><value>Z</value></data>
+<data name="ZDesc" xml:space="preserve"><value>Z軸移動距離</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/AudioVolumeOpacityEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/AudioVolumeOpacityEffect.cs
@@ -1,0 +1,37 @@
+﻿using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase;
+using YukkuriMovieMaker.Plugin.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Opacity
+{
+    [VideoEffect(nameof(Texts.AudioVolumeOpacityEffect), [VideoEffectCategories.Animation], ["不透明度", "audio volume opacity"], IsAviUtlSupported = false, IsEffectItemSupported = false, ResourceType = typeof(Texts))]
+    internal class AudioVolumeOpacityEffect : AudioVolumeVideoEffectBase
+    {
+        public override string Label => $"{Texts.AudioVolumeOpacityEffect} {Opacity.GetValue(0, 1, 30):F0}%";
+
+        [Display(GroupName = nameof(Texts.AudioVolumeOpacityEffect), Name = nameof(Texts.Opacity), Description = nameof(Texts.Opacity), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 100)]
+        public Animation Opacity { get; } = new Animation(0, 0, 100);
+
+        [Display(GroupName = nameof(Texts.AudioVolumeOpacityEffect), Name = nameof(Texts.Invert), Description = nameof(Texts.InvertDesc), ResourceType = typeof(Texts))]
+        [ToggleSlider]
+        public bool Invert { get => invert; set => Set(ref invert, value); }
+        bool invert = false;
+
+        public override IEnumerable<string> CreateExoVideoFilters(int keyFrameIndex, ExoOutputDescription exoOutputDescription)
+        {
+            return [];
+        }
+
+        public override IVideoEffectProcessor CreateVideoEffect(IGraphicsDevicesAndContext devices)
+        {
+            return new AudioVolumeOpacityEffectProcessor(devices, this);
+        }
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [Opacity, ..base.GetAnimatables()];
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/AudioVolumeOpacityEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/AudioVolumeOpacityEffectProcessor.cs
@@ -1,0 +1,36 @@
+﻿using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Opacity
+{
+    internal class AudioVolumeOpacityEffectProcessor(IGraphicsDevicesAndContext devices, AudioVolumeOpacityEffect item) : AudioVolumeVideoEffectProcessorBase(devices, item)
+    {
+        public override DrawDescription Update(EffectDescription effectDescription, double audioVolume)
+        {
+            var frame = effectDescription.ItemPosition.Frame;
+            var length = effectDescription.ItemDuration.Frame;
+            var fps = effectDescription.FPS;
+            var invert = item.Invert;
+            var opacity = invert ? item.Opacity.GetValue(frame, length, fps) / 100.0 * (1.0 - audioVolume) + audioVolume : item.Opacity.GetValue(frame, length, fps) / 100.0 * audioVolume + 1.0 - audioVolume;
+
+            var drawDescription = effectDescription.DrawDescription;
+
+            return drawDescription with { Opacity = drawDescription.Opacity * opacity };
+        }
+
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            return null;
+        }
+
+        protected override void setInput(ID2D1Image? input)
+        {
+        }
+
+        protected override void ClearEffectChain()
+        {
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.ar-sa.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.ar-sa.resx
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ar-sa</value></data>
+<data name="AudioVolumeOpacityEffect" xml:space="preserve"><value>الشفافية حسب مستوى الصوت</value></data>
+<data name="Opacity" xml:space="preserve"><value>العتامة</value></data>
+<data name="Invert" xml:space="preserve"><value>عكس</value></data>
+<data name="InvertDesc" xml:space="preserve"><value>زيادة العتامة مع ارتفاع مستوى الصوت</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.cs
@@ -1,0 +1,9 @@
+﻿using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Opacity
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.csv
@@ -1,0 +1,5 @@
+﻿Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+AudioVolumeOpacityEffect,,音量に合わせて透過,Transparency According to Volume,根据音量透明,根據音量透明,음량에 따라 투명도 조절,Transparencia según el volumen,الشفافية حسب مستوى الصوت,Transparansi Sesuai Volume
+Opacity,,不透明度,Opacity,不透明度,不透明度,불투명도,Opacidad,العتامة,Opasitas
+Invert,,反転,Inversion,反转,反轉,반전,Inversión,عكس,Pembalikan
+InvertDesc,,音量が上がるにつれて不透明度が上がるようにする,Increase Opacity as Volume Increases,音量增加时提高不透明度,音量增加時提高不透明度,음량이 증가할수록 불투명도 증가,Aumentar la opacidad a medida que sube el volumen,زيادة العتامة مع ارتفاع مستوى الصوت,Meningkatkan Opasitas Seiring Bertambahnya Volume

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.en-us.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.en-us.resx
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>en-us</value></data>
+<data name="AudioVolumeOpacityEffect" xml:space="preserve"><value>Transparency According to Volume</value></data>
+<data name="Opacity" xml:space="preserve"><value>Opacity</value></data>
+<data name="Invert" xml:space="preserve"><value>Inversion</value></data>
+<data name="InvertDesc" xml:space="preserve"><value>Increase Opacity as Volume Increases</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.es-es.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.es-es.resx
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>es-es</value></data>
+<data name="AudioVolumeOpacityEffect" xml:space="preserve"><value>Transparencia según el volumen</value></data>
+<data name="Opacity" xml:space="preserve"><value>Opacidad</value></data>
+<data name="Invert" xml:space="preserve"><value>Inversión</value></data>
+<data name="InvertDesc" xml:space="preserve"><value>Aumentar la opacidad a medida que sube el volumen</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.id-id.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.id-id.resx
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>id-id</value></data>
+<data name="AudioVolumeOpacityEffect" xml:space="preserve"><value>Transparansi Sesuai Volume</value></data>
+<data name="Opacity" xml:space="preserve"><value>Opasitas</value></data>
+<data name="Invert" xml:space="preserve"><value>Pembalikan</value></data>
+<data name="InvertDesc" xml:space="preserve"><value>Meningkatkan Opasitas Seiring Bertambahnya Volume</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.ko-kr.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.ko-kr.resx
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ko-kr</value></data>
+<data name="AudioVolumeOpacityEffect" xml:space="preserve"><value>음량에 따라 투명도 조절</value></data>
+<data name="Opacity" xml:space="preserve"><value>불투명도</value></data>
+<data name="Invert" xml:space="preserve"><value>반전</value></data>
+<data name="InvertDesc" xml:space="preserve"><value>음량이 증가할수록 불투명도 증가</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.resx
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ja-jp</value></data>
+<data name="AudioVolumeOpacityEffect" xml:space="preserve"><value>音量に合わせて透過</value></data>
+<data name="Opacity" xml:space="preserve"><value>不透明度</value></data>
+<data name="Invert" xml:space="preserve"><value>反転</value></data>
+<data name="InvertDesc" xml:space="preserve"><value>音量が上がるにつれて不透明度が上がるようにする</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.zh-cn.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.zh-cn.resx
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-cn</value></data>
+<data name="AudioVolumeOpacityEffect" xml:space="preserve"><value>根据音量透明</value></data>
+<data name="Opacity" xml:space="preserve"><value>不透明度</value></data>
+<data name="Invert" xml:space="preserve"><value>反转</value></data>
+<data name="InvertDesc" xml:space="preserve"><value>音量增加时提高不透明度</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.zh-tw.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Opacity/Texts.zh-tw.resx
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-tw</value></data>
+<data name="AudioVolumeOpacityEffect" xml:space="preserve"><value>根據音量透明</value></data>
+<data name="Opacity" xml:space="preserve"><value>不透明度</value></data>
+<data name="Invert" xml:space="preserve"><value>反轉</value></data>
+<data name="InvertDesc" xml:space="preserve"><value>音量增加時提高不透明度</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/AudioVolumeRotateEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/AudioVolumeRotateEffect.cs
@@ -1,0 +1,45 @@
+﻿using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase;
+using YukkuriMovieMaker.Plugin.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Rotate
+{
+    [VideoEffect(nameof(Texts.AudioVolumeRotateEffect), [VideoEffectCategories.Animation], ["角度", "audio volume rotate", "audio volume rotation", "audio volume angle"], IsAviUtlSupported = false, IsEffectItemSupported = false, ResourceType = typeof(Texts))]
+    internal class AudioVolumeRotateEffect : AudioVolumeVideoEffectBase
+    {
+        public override string Label => $"{Texts.AudioVolumeRotateEffect} X{X.GetValue(0, 1, 30):F1}°, Y{X.GetValue(0, 1, 30):F1}°, Z{X.GetValue(0, 1, 30):F1}";
+
+        [Display(GroupName = nameof(Texts.AudioVolumeRotateEffect), Name = nameof(Texts.X), Description = nameof(Texts.XDesc), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "°", 0.0, 360.0)]
+        public Animation X { get; } = new Animation(0.0, 0.0, 3600.0);
+
+        [Display(GroupName = nameof(Texts.AudioVolumeRotateEffect), Name = nameof(Texts.Y), Description = nameof(Texts.YDesc), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "°", 0.0, 360.0)]
+        public Animation Y { get; } = new Animation(0.0, 0.0, 3600.0);
+
+        [Display(GroupName = nameof(Texts.AudioVolumeRotateEffect), Name = nameof(Texts.Z), Description = nameof(Texts.ZDesc), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "°", 0.0, 360.0)]
+        public Animation Z { get; } = new Animation(30.0, 0.0, 3600.0);
+
+        [Display(GroupName = nameof(Texts.AudioVolumeRotateEffect), Name = nameof(Texts.Is3D), Description = nameof(Texts.Is3DDesc), ResourceType = typeof(Texts))]
+        [ToggleSlider]
+        public bool Is3D { get => is3D; set => Set(ref is3D, value); }
+        bool is3D = false;
+
+        public override IEnumerable<string> CreateExoVideoFilters(int keyFrameIndex, ExoOutputDescription exoOutputDescription)
+        {
+            return [];
+        }
+
+        public override IVideoEffectProcessor CreateVideoEffect(IGraphicsDevicesAndContext devices)
+        {
+            return new AudioVolumeRotateEffectProcessor(devices, this);
+        }
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [X, Y, Z, ..base.GetAnimatables()];
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/AudioVolumeRotateEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/AudioVolumeRotateEffectProcessor.cs
@@ -55,7 +55,11 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Rotate
                 matrix3D = Matrix4x4.CreateRotationZ(z / 180f * MathF.PI) 
                     * Matrix4x4.CreateRotationY(-y / 180f * MathF.PI) 
                     * Matrix4x4.CreateRotationX(-x / 180f * MathF.PI) 
-                    * new Matrix4x4(1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, -0.001f, 0f, 0f, 0f, 1f);
+                    * new Matrix4x4(
+                        1f, 0f, 0f, 0f,
+                        0f, 1f, 0f, 0f,
+                        0f, 0f, 1f, -0.001f,
+                        0f, 0f, 0f, 1f);
             }
 
             if (isFirst || this.matrix2D != matrix2D)
@@ -71,7 +75,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Rotate
             RawRectF imageLocalBounds = devices.DeviceContext.GetImageLocalBounds(renderOutput);
             if ((double)imageLocalBounds.Left == (double)int.MinValue || (double)imageLocalBounds.Top == (double)int.MinValue || (double)imageLocalBounds.Right == 2147483648.0 || (double)imageLocalBounds.Bottom == 2147483648.0)
                 cropEffect.Rectangle = new(-2048f, -2048f, 2048f, 2048f);
-
+            
             isFirst = false;
             this.matrix2D = matrix2D;
             this.matrix3D = matrix3D;

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/AudioVolumeRotateEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/AudioVolumeRotateEffectProcessor.cs
@@ -1,0 +1,126 @@
+﻿using System.Numerics;
+using Vortice;
+using Vortice.Direct2D1;
+using Vortice.Direct2D1.Effects;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Rotate
+{
+    internal class AudioVolumeRotateEffectProcessor(IGraphicsDevicesAndContext devices, AudioVolumeRotateEffect item) : AudioVolumeVideoEffectProcessorBase(devices, item)
+    {
+        readonly IGraphicsDevicesAndContext devices = devices;
+
+        AffineTransform2D? transform2D;
+        Crop? cropEffect;
+        Transform3D? transform3D;
+        ID2D1Image? renderOutput;
+
+        bool isFirst = true;
+        Matrix3x2 matrix2D;
+        Matrix4x4 matrix3D;
+        AffineTransform2DInterpolationMode interpolationMode2D;
+        Transform3DInterpolationMode interpolationMode3D;
+
+        public override DrawDescription Update(EffectDescription effectDescription, double audioVolume)
+        {
+            if (transform2D is null || cropEffect is null || transform3D is null || renderOutput is null)
+                return effectDescription.DrawDescription;
+
+            var frame = effectDescription.ItemPosition.Frame;
+            var length = effectDescription.ItemDuration.Frame;
+            var fps = effectDescription.FPS;
+
+            var x = (float)(item.X.GetValue(frame, length, fps) * audioVolume);
+            var y = (float)(item.Y.GetValue(frame, length, fps) * audioVolume);
+            var z = (float)(item.Z.GetValue(frame, length, fps) * audioVolume);
+            var is3D = item.Is3D;
+
+            var drawDescription = effectDescription.DrawDescription;
+            var interpolationMode2D = drawDescription.ZoomInterpolationMode.ToTransform2D();
+            var interpolationMode3D = drawDescription.ZoomInterpolationMode.ToTransform3D();
+            var zoom = drawDescription.Zoom;
+
+            Matrix3x2 matrix2D;
+            Matrix4x4 matrix3D;
+            if (is3D)
+            {
+                matrix2D = Matrix3x2.Identity;
+                matrix3D = Matrix4x4.Identity;
+            }
+            else
+            {
+                matrix2D = Matrix3x2.CreateScale(zoom);
+                matrix3D = Matrix4x4.CreateRotationZ(z / 180f * MathF.PI) 
+                    * Matrix4x4.CreateRotationY(-y / 180f * MathF.PI) 
+                    * Matrix4x4.CreateRotationX(-x / 180f * MathF.PI) 
+                    * new Matrix4x4(1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, -0.001f, 0f, 0f, 0f, 1f);
+            }
+
+            if (isFirst || this.matrix2D != matrix2D)
+                transform2D.TransformMatrix = matrix2D;
+            if (isFirst || this.matrix3D != matrix3D)
+                transform3D.TransformMatrix = matrix3D;
+            if (isFirst || this.interpolationMode2D != interpolationMode2D)
+                transform2D.InterPolationMode = interpolationMode2D;
+            if (isFirst || this.interpolationMode3D != interpolationMode3D)
+                transform3D.InterPolationMode = interpolationMode3D;
+
+            cropEffect.Rectangle = new Vector4(float.MinValue, float.MinValue, float.MaxValue, float.MaxValue);
+            RawRectF imageLocalBounds = devices.DeviceContext.GetImageLocalBounds(renderOutput);
+            if ((double)imageLocalBounds.Left == (double)int.MinValue || (double)imageLocalBounds.Top == (double)int.MinValue || (double)imageLocalBounds.Right == 2147483648.0 || (double)imageLocalBounds.Bottom == 2147483648.0)
+                cropEffect.Rectangle = new(-2048f, -2048f, 2048f, 2048f);
+
+            isFirst = false;
+            this.matrix2D = matrix2D;
+            this.matrix3D = matrix3D;
+            this.interpolationMode2D = interpolationMode2D;
+            this.interpolationMode3D = interpolationMode3D;
+
+            return drawDescription with
+            {
+                Rotation = is3D ? drawDescription.Rotation + new Vector3(x, y, z) : drawDescription.Rotation,
+                Zoom = is3D ? drawDescription.Zoom : new Vector2(1f, 1f)
+            };
+        }
+
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            transform2D = new AffineTransform2D(devices.DeviceContext);
+            disposer.Collect(transform2D);
+
+            cropEffect = new Crop(devices.DeviceContext);
+            disposer.Collect(cropEffect);
+
+            transform3D = new Transform3D(devices.DeviceContext);
+            disposer.Collect(transform3D);
+
+            using (var output = transform2D.Output) 
+            {
+                cropEffect.SetInput(0, output, true);
+            }
+
+            using (var output = cropEffect.Output)
+            {
+                transform3D.SetInput(0, output, true);
+            }
+
+            renderOutput = transform3D.Output;
+            disposer.Collect(renderOutput);
+            return renderOutput;
+        }
+
+        protected override void setInput(ID2D1Image? input)
+        {
+            transform2D?.SetInput(0, input, true);
+        }
+
+        protected override void ClearEffectChain()
+        {
+            transform2D?.SetInput(0, null, true);
+            cropEffect?.SetInput(0, null, true);
+            transform3D?.SetInput(0, null, true);
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.ar-sa.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.ar-sa.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ar-sa</value></data>
+<data name="AudioVolumeRotateEffect" xml:space="preserve"><value>الدوران حسب مستوى الصوت</value></data>
+<data name="X" xml:space="preserve"><value>المحور X</value></data>
+<data name="XDesc" xml:space="preserve"><value>زاوية الدوران الرأسية حول المحور X</value></data>
+<data name="Y" xml:space="preserve"><value>المحور Y</value></data>
+<data name="YDesc" xml:space="preserve"><value>زاوية الدوران الأفقية حول المحور Y</value></data>
+<data name="Z" xml:space="preserve"><value>المحور Z</value></data>
+<data name="ZDesc" xml:space="preserve"><value>زاوية الدوران في المستوى حول المحور Z</value></data>
+<data name="Is3D" xml:space="preserve"><value>ترتيب ثلاثي الأبعاد</value></data>
+<data name="Is3DDesc" xml:space="preserve"><value>وضع في الفضاء ثلاثي الأبعاد</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.cs
@@ -1,0 +1,9 @@
+﻿using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Rotate
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.csv
@@ -1,0 +1,10 @@
+﻿Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+AudioVolumeRotateEffect,,音量に合わせて回転,Rotate According to Volume,根据音量旋转,根據音量旋轉,음량에 따라 회전,Rotar según el volumen,الدوران حسب مستوى الصوت,Berputar Sesuai Volume
+X,,X軸,X Axis,X轴,X軸,X축,Eje X,المحور X,Sumbu X
+XDesc,,縦方向、X軸に対する回転角,Vertical Rotation Angle around X Axis,绕X轴的垂直旋转角,繞X軸的垂直旋轉角,X축 기준 수직 회전 각도,Ángulo de rotación vertical alrededor del eje X,زاوية الدوران الرأسية حول المحور X,Sudut Rotasi Vertikal terhadap Sumbu X
+Y,,Y軸,Y Axis,Y轴,Y軸,Y축,Eje Y,المحور Y,Sumbu Y
+YDesc,,横方向、Y軸に対する回転角,Horizontal Rotation Angle around Y Axis,绕Y轴的水平旋转角,繞Y軸的水平旋轉角,Y축 기준 수평 회전 각도,Ángulo de rotación horizontal alrededor del eje Y,زاوية الدوران الأفقية حول المحور Y,Sudut Rotasi Horizontal terhadap Sumbu Y
+Z,,Z軸,Z Axis,Z轴,Z軸,Z축,Eje Z,المحور Z,Sumbu Z
+ZDesc,,平面方向、Z軸に対する回転角,Planar Rotation Angle around Z Axis,绕Z轴的平面旋转角,繞Z軸的平面旋轉角,Z축 기준 평면 회전 각도,Ángulo de rotación en el plano alrededor del eje Z,زاوية الدوران في المستوى حول المحور Z,Sudut Rotasi Datar terhadap Sumbu Z
+Is3D,,三次元配置,3D Arrangement,三维布置,三維配置,3차원 배치,Disposición 3D,ترتيب ثلاثي الأبعاد,Penataan 3D
+Is3DDesc,,3次元空間上に配置します,Place in 3D Space,放置在三维空间中,放置在三維空間中,3차원 공간에 배치합니다,Colocar en espacio 3D,وضع في الفضاء ثلاثي الأبعاد,Tempatkan di Ruang 3D

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.en-us.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.en-us.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>en-us</value></data>
+<data name="AudioVolumeRotateEffect" xml:space="preserve"><value>Rotate According to Volume</value></data>
+<data name="X" xml:space="preserve"><value>X Axis</value></data>
+<data name="XDesc" xml:space="preserve"><value>Vertical Rotation Angle around X Axis</value></data>
+<data name="Y" xml:space="preserve"><value>Y Axis</value></data>
+<data name="YDesc" xml:space="preserve"><value>Horizontal Rotation Angle around Y Axis</value></data>
+<data name="Z" xml:space="preserve"><value>Z Axis</value></data>
+<data name="ZDesc" xml:space="preserve"><value>Planar Rotation Angle around Z Axis</value></data>
+<data name="Is3D" xml:space="preserve"><value>3D Arrangement</value></data>
+<data name="Is3DDesc" xml:space="preserve"><value>Place in 3D Space</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.es-es.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.es-es.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>es-es</value></data>
+<data name="AudioVolumeRotateEffect" xml:space="preserve"><value>Rotar según el volumen</value></data>
+<data name="X" xml:space="preserve"><value>Eje X</value></data>
+<data name="XDesc" xml:space="preserve"><value>Ángulo de rotación vertical alrededor del eje X</value></data>
+<data name="Y" xml:space="preserve"><value>Eje Y</value></data>
+<data name="YDesc" xml:space="preserve"><value>Ángulo de rotación horizontal alrededor del eje Y</value></data>
+<data name="Z" xml:space="preserve"><value>Eje Z</value></data>
+<data name="ZDesc" xml:space="preserve"><value>Ángulo de rotación en el plano alrededor del eje Z</value></data>
+<data name="Is3D" xml:space="preserve"><value>Disposición 3D</value></data>
+<data name="Is3DDesc" xml:space="preserve"><value>Colocar en espacio 3D</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.id-id.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.id-id.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>id-id</value></data>
+<data name="AudioVolumeRotateEffect" xml:space="preserve"><value>Berputar Sesuai Volume</value></data>
+<data name="X" xml:space="preserve"><value>Sumbu X</value></data>
+<data name="XDesc" xml:space="preserve"><value>Sudut Rotasi Vertikal terhadap Sumbu X</value></data>
+<data name="Y" xml:space="preserve"><value>Sumbu Y</value></data>
+<data name="YDesc" xml:space="preserve"><value>Sudut Rotasi Horizontal terhadap Sumbu Y</value></data>
+<data name="Z" xml:space="preserve"><value>Sumbu Z</value></data>
+<data name="ZDesc" xml:space="preserve"><value>Sudut Rotasi Datar terhadap Sumbu Z</value></data>
+<data name="Is3D" xml:space="preserve"><value>Penataan 3D</value></data>
+<data name="Is3DDesc" xml:space="preserve"><value>Tempatkan di Ruang 3D</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.ko-kr.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.ko-kr.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ko-kr</value></data>
+<data name="AudioVolumeRotateEffect" xml:space="preserve"><value>음량에 따라 회전</value></data>
+<data name="X" xml:space="preserve"><value>X축</value></data>
+<data name="XDesc" xml:space="preserve"><value>X축 기준 수직 회전 각도</value></data>
+<data name="Y" xml:space="preserve"><value>Y축</value></data>
+<data name="YDesc" xml:space="preserve"><value>Y축 기준 수평 회전 각도</value></data>
+<data name="Z" xml:space="preserve"><value>Z축</value></data>
+<data name="ZDesc" xml:space="preserve"><value>Z축 기준 평면 회전 각도</value></data>
+<data name="Is3D" xml:space="preserve"><value>3차원 배치</value></data>
+<data name="Is3DDesc" xml:space="preserve"><value>3차원 공간에 배치합니다</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ja-jp</value></data>
+<data name="AudioVolumeRotateEffect" xml:space="preserve"><value>音量に合わせて回転</value></data>
+<data name="X" xml:space="preserve"><value>X軸</value></data>
+<data name="XDesc" xml:space="preserve"><value>縦方向、X軸に対する回転角</value></data>
+<data name="Y" xml:space="preserve"><value>Y軸</value></data>
+<data name="YDesc" xml:space="preserve"><value>横方向、Y軸に対する回転角</value></data>
+<data name="Z" xml:space="preserve"><value>Z軸</value></data>
+<data name="ZDesc" xml:space="preserve"><value>平面方向、Z軸に対する回転角</value></data>
+<data name="Is3D" xml:space="preserve"><value>三次元配置</value></data>
+<data name="Is3DDesc" xml:space="preserve"><value>3次元空間上に配置します</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.zh-cn.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.zh-cn.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-cn</value></data>
+<data name="AudioVolumeRotateEffect" xml:space="preserve"><value>根据音量旋转</value></data>
+<data name="X" xml:space="preserve"><value>X轴</value></data>
+<data name="XDesc" xml:space="preserve"><value>绕X轴的垂直旋转角</value></data>
+<data name="Y" xml:space="preserve"><value>Y轴</value></data>
+<data name="YDesc" xml:space="preserve"><value>绕Y轴的水平旋转角</value></data>
+<data name="Z" xml:space="preserve"><value>Z轴</value></data>
+<data name="ZDesc" xml:space="preserve"><value>绕Z轴的平面旋转角</value></data>
+<data name="Is3D" xml:space="preserve"><value>三维布置</value></data>
+<data name="Is3DDesc" xml:space="preserve"><value>放置在三维空间中</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.zh-tw.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Rotate/Texts.zh-tw.resx
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-tw</value></data>
+<data name="AudioVolumeRotateEffect" xml:space="preserve"><value>根據音量旋轉</value></data>
+<data name="X" xml:space="preserve"><value>X軸</value></data>
+<data name="XDesc" xml:space="preserve"><value>繞X軸的垂直旋轉角</value></data>
+<data name="Y" xml:space="preserve"><value>Y軸</value></data>
+<data name="YDesc" xml:space="preserve"><value>繞Y軸的水平旋轉角</value></data>
+<data name="Z" xml:space="preserve"><value>Z軸</value></data>
+<data name="ZDesc" xml:space="preserve"><value>繞Z軸的平面旋轉角</value></data>
+<data name="Is3D" xml:space="preserve"><value>三維配置</value></data>
+<data name="Is3DDesc" xml:space="preserve"><value>放置在三維空間中</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/AudioVolumeSkewEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/AudioVolumeSkewEffect.cs
@@ -1,0 +1,52 @@
+﻿using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase;
+using YukkuriMovieMaker.Plugin.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Skew
+{
+    [VideoEffect(nameof(Texts.AudioVolumeSkewEffect), [VideoEffectCategories.Animation], ["audio volume skew"], IsAviUtlSupported = false, IsEffectItemSupported = false, ResourceType = typeof(Texts))]
+    internal class AudioVolumeSkewEffect : AudioVolumeVideoEffectBase
+    {
+        public override string Label => Texts.AudioVolumeSkewEffect;
+
+        [Display(GroupName = nameof(Texts.AudioVolumeSkewEffect), Name = nameof(Texts.AngleX), Description = nameof(Texts.AngleXDesc), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "°", -90.0, 90.0)]
+        public Animation AngleX { get; } = new Animation(0.0, -3600.0, 3600.0, 360.0);
+
+        [Display(GroupName = nameof(Texts.AudioVolumeSkewEffect), Name = nameof(Texts.AngleY), Description = nameof(Texts.AngleYDesc), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "°", -90.0, 90.0)]
+        public Animation AngleY { get; } = new Animation(0.0, -3600.0, 3600.0, 360.0);
+
+        [Display(GroupName = nameof(Texts.AudioVolumeSkewEffect), Name = nameof(Texts.CenterPoint), Description = nameof(Texts.CenterPointDesc), ResourceType = typeof(Texts))]
+        [EnumComboBox]
+        public SkewCenterPoint CenterPoint { get => centerPoint; set => Set(ref centerPoint, value); }
+        SkewCenterPoint centerPoint = SkewCenterPoint.Center;
+
+        [Display(GroupName = nameof(Texts.AudioVolumeSkewEffect), Name = nameof(CenterX), Description = nameof(Texts.CenterXDesc), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", -500.0, 500.0)]
+        [SkewCenterPointCustomVisible]
+        public Animation CenterX { get; } = new Animation(0.0, -99999.0, 99999.0);
+
+        [Display(GroupName = nameof(Texts.AudioVolumeSkewEffect), Name = nameof(CenterY), Description = nameof(Texts.CenterYDesc), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", -500.0, 500.0)]
+        [SkewCenterPointCustomVisible]
+        public Animation CenterY { get; } = new Animation(0.0, -99999.0, 99999.0);
+
+
+        public override IEnumerable<string> CreateExoVideoFilters(int keyFrameIndex, ExoOutputDescription exoOutputDescription)
+        {
+            return [];
+        }
+
+        public override IVideoEffectProcessor CreateVideoEffect(IGraphicsDevicesAndContext devices)
+        {
+            return new AudioVolumeSkewEffectProcessor(devices, this);
+        }
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [AngleX, AngleY, CenterX, CenterY, ..base.GetAnimatables()];
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/AudioVolumeSkewEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/AudioVolumeSkewEffectProcessor.cs
@@ -1,0 +1,110 @@
+﻿using System.Numerics;
+using Vortice;
+using Vortice.Direct2D1;
+using Vortice.Direct2D1.Effects;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Skew
+{
+    internal class AudioVolumeSkewEffectProcessor(IGraphicsDevicesAndContext devices, AudioVolumeSkewEffect item) : AudioVolumeVideoEffectProcessorBase(devices, item)
+    {
+        readonly IGraphicsDevicesAndContext devices = devices;
+
+        AffineTransform2D? transform2D;
+
+        bool isFirst = true;
+        float angleX,angleY,centerX,centerY;
+        AffineTransform2DInterpolationMode interpolationMode;
+
+        public override DrawDescription Update(EffectDescription effectDescription, double audioVolume)
+        {
+            if (transform2D is null)
+                return effectDescription.DrawDescription;
+
+            var frame = effectDescription.ItemPosition.Frame;
+            var length = effectDescription.ItemDuration.Frame;
+            var fps = effectDescription.FPS;
+
+            var angleX = (float)(item.AngleX.GetValue(frame, length, fps) * audioVolume);
+            var angleY = (float)(item.AngleY.GetValue(frame,length, fps) * audioVolume);
+            var interpolationMode = effectDescription.DrawDescription.ZoomInterpolationMode.ToTransform2D();
+            float centerX, centerY;
+            if (item.CenterPoint == SkewCenterPoint.Center)
+            {
+                centerX = 0f;
+                centerY = 0f;
+            }
+            else if (item.CenterPoint == SkewCenterPoint.Custom)
+            {
+                centerX = (float)item.CenterX.GetValue(frame, length, fps);
+                centerY = (float)item.CenterX.GetValue(frame, length, fps);
+            }
+            else
+            {
+                RawRectF imageLocalBounds = devices.DeviceContext.GetImageLocalBounds(input);
+                if (item.CenterPoint == SkewCenterPoint.Top)
+                {
+                    centerX = 0f;
+                    centerY = imageLocalBounds.Top;
+                }
+                else if (item.CenterPoint == SkewCenterPoint.Bottom)
+                {
+                    centerX = 0f;
+                    centerY = imageLocalBounds.Bottom;
+                }
+                else if (item.CenterPoint == SkewCenterPoint.Left)
+                {
+                    centerX = imageLocalBounds.Left;
+                    centerY = 0f;
+                }
+                else if (item.CenterPoint == SkewCenterPoint.Right)
+                {
+                    centerX = imageLocalBounds.Right;
+                    centerY = 0f;
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            if (isFirst || this.angleX != angleX || this.angleY != angleY || this.centerX != centerX || this.centerY != centerY)
+                transform2D.TransformMatrix = Matrix3x2.CreateSkew(angleX / 180f * MathF.PI, angleY / 180f * MathF.PI, new(centerX, centerY));
+
+            if (isFirst || this.interpolationMode != interpolationMode)
+                transform2D.InterPolationMode = interpolationMode;
+
+            isFirst = false;
+            this.angleX = angleX;
+            this.angleY = angleY;
+            this.centerX = centerX;
+            this.centerY = centerY;
+            this.interpolationMode = interpolationMode;
+
+            return effectDescription.DrawDescription;
+        }
+
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            transform2D = new AffineTransform2D(devices.DeviceContext);
+            disposer.Collect(transform2D);
+
+            ID2D1Image output = transform2D.Output;
+            disposer.Collect(output);
+
+            return output;
+        }
+
+        protected override void setInput(ID2D1Image? input)
+        {
+            transform2D?.SetInput(0, input, true);
+        }
+
+        protected override void ClearEffectChain()
+        {
+            transform2D?.SetInput(0, null, true);
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/SkewCenterPoint.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/SkewCenterPoint.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Skew
+{
+    internal enum SkewCenterPoint
+    {
+        [Display(Name = nameof(Texts.SkewCenterPointCenter), Description = nameof(Texts.SkewCenterPointCenter), ResourceType = typeof(Texts))]
+        Center,
+        [Display(Name = nameof(Texts.SkewCenterPointTop), Description = nameof(Texts.SkewCenterPointTop), ResourceType = typeof(Texts))]
+        Top,
+        [Display(Name = nameof(Texts.SkewCenterPointBottom), Description = nameof(Texts.SkewCenterPointBottom), ResourceType = typeof(Texts))]
+        Bottom,
+        [Display(Name = nameof(Texts.SkewCenterPointLeft), Description = nameof(Texts.SkewCenterPointLeft), ResourceType = typeof(Texts))]
+        Left,
+        [Display(Name = nameof(Texts.SkewCenterPointRight), Description = nameof(Texts.SkewCenterPointRight), ResourceType = typeof(Texts))]
+        Right,
+        [Display(Name = nameof(Texts.SkewCenterPointCustom), Description = nameof(Texts.SkewCenterPointCustom), ResourceType = typeof(Texts))]
+        Custom,
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/SkewCenterPointCustomVisibleAttribute.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/SkewCenterPointCustomVisibleAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System.Windows.Data;
+using YukkuriMovieMaker.ItemEditor;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Skew
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    internal class SkewCenterPointCustomVisibleAttribute : Attribute, ICustomVisibilityAttribute2
+    {
+        public Binding GetBinding(object item, object propertyOwner)
+        {
+            return new Binding(nameof(AudioVolumeSkewEffect.CenterPoint))
+            {
+                Source = item,
+                Converter = new SkewCenterPointCustomVisibleConverter()
+            };
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/SkewCenterPointCustomVisibleConverter.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/SkewCenterPointCustomVisibleConverter.cs
@@ -1,0 +1,19 @@
+﻿using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Skew
+{
+    internal class SkewCenterPointCustomVisibleConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value is SkewCenterPoint.Custom ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.ar-sa.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.ar-sa.resx
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ar-sa</value></data>
+<data name="AudioVolumeSkewEffect" xml:space="preserve"><value>تحويل الميلان حسب مستوى الصوت</value></data>
+<data name="AngleX" xml:space="preserve"><value>الاتجاه X</value></data>
+<data name="AngleXDesc" xml:space="preserve"><value>زاوية الاتجاه X</value></data>
+<data name="AngleY" xml:space="preserve"><value>الاتجاه Y</value></data>
+<data name="AngleYDesc" xml:space="preserve"><value>زاوية الاتجاه Y</value></data>
+<data name="CenterPoint" xml:space="preserve"><value>المركز</value></data>
+<data name="CenterPointDesc" xml:space="preserve"><value>مركز التحويل</value></data>
+<data name="SkewCenterPointCenter" xml:space="preserve"><value>المنتصف</value></data>
+<data name="SkewCenterPointTop" xml:space="preserve"><value>الحافة العلوية</value></data>
+<data name="SkewCenterPointBottom" xml:space="preserve"><value>الحافة السفلية</value></data>
+<data name="SkewCenterPointLeft" xml:space="preserve"><value>الحافة اليسرى</value></data>
+<data name="SkewCenterPointRight" xml:space="preserve"><value>الحافة اليمنى</value></data>
+<data name="SkewCenterPointCustom" xml:space="preserve"><value>مخصص</value></data>
+<data name="CenterX" xml:space="preserve"><value>المركز X</value></data>
+<data name="CenterXDesc" xml:space="preserve"><value>مركز التحويل X</value></data>
+<data name="CenterY" xml:space="preserve"><value>المركز Y</value></data>
+<data name="CenterYDesc" xml:space="preserve"><value>مركز التحويل Y</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.cs
@@ -1,0 +1,9 @@
+﻿using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Skew
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.csv
@@ -1,0 +1,18 @@
+﻿Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+AudioVolumeSkewEffect,,音量に合わせて傾斜変形,Skew Transformation According to Volume,根据音量进行倾斜变形,根據音量進行傾斜變形,음량에 따라 기울기 변형,Transformación de sesgado según el volumen,تحويل الميلان حسب مستوى الصوت,Transformasi Miring Sesuai Volume
+AngleX,,X方向,X Direction,X方向,X方向,X 방향,Dirección X,الاتجاه X,Arah X
+AngleXDesc,,X方向の角度,Angle in X Direction,X方向的角度,X方向的角度,X 방향의 각도,Ángulo en la dirección X,زاوية الاتجاه X,Sudut Arah X
+AngleY,,Y方向,Y Direction,Y方向,Y方向,Y 방향,Dirección Y,الاتجاه Y,Arah Y
+AngleYDesc,,Y方向の角度,Angle in Y Direction,Y方向的角度,Y方向的角度,Y 방향의 각도,Ángulo en la dirección Y,زاوية الاتجاه Y,Sudut Arah Y
+CenterPoint,,中心,Center,中心,中心,중심,Centro,المركز,Pusat
+CenterPointDesc,,変形の中心,Center of Transformation,变形中心,變形中心,변형의 중심,Centro de transformación,مركز التحويل,Pusat Transformasi
+SkewCenterPointCenter,,中央,Middle,中央,中央,중앙,Centro,المنتصف,Tengah
+SkewCenterPointTop,,上辺,Top Edge,上边,上邊,윗변,Borde superior,الحافة العلوية,Tepi Atas
+SkewCenterPointBottom,,下辺,Bottom Edge,下边,下邊,아랫변,Borde inferior,الحافة السفلية,Tepi Bawah
+SkewCenterPointLeft,,左辺,Left Edge,左边,左邊,왼쪽 변,Borde izquierdo,الحافة اليسرى,Tepi Kiri
+SkewCenterPointRight,,右辺,Right Edge,右边,右邊,오른쪽 변,Borde derecho,الحافة اليمنى,Tepi Kanan
+SkewCenterPointCustom,,カスタム,Custom,自定义,自訂,커스텀,Personalizado,مخصص,Kustom
+CenterX,,中心X,Center X,中心X,中心X,중심 X,Centro X,المركز X,Tengah X
+CenterXDesc,,変形の中心X,Center of Transformation X,变形中心X,變形中心X,변형의 중심 X,Centro de transformación X,مركز التحويل X,Pusat Transformasi X
+CenterY,,中心Y,Center Y,中心Y,中心Y,중심 Y,Centro Y,المركز Y,Tengah Y
+CenterYDesc,,変形の中心Y,Center of Transformation Y,变形中心Y,變形中心Y,변형의 중심 Y,Centro de transformación Y,مركز التحويل Y,Pusat Transformasi Y

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.en-us.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.en-us.resx
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>en-us</value></data>
+<data name="AudioVolumeSkewEffect" xml:space="preserve"><value>Skew Transformation According to Volume</value></data>
+<data name="AngleX" xml:space="preserve"><value>X Direction</value></data>
+<data name="AngleXDesc" xml:space="preserve"><value>Angle in X Direction</value></data>
+<data name="AngleY" xml:space="preserve"><value>Y Direction</value></data>
+<data name="AngleYDesc" xml:space="preserve"><value>Angle in Y Direction</value></data>
+<data name="CenterPoint" xml:space="preserve"><value>Center</value></data>
+<data name="CenterPointDesc" xml:space="preserve"><value>Center of Transformation</value></data>
+<data name="SkewCenterPointCenter" xml:space="preserve"><value>Middle</value></data>
+<data name="SkewCenterPointTop" xml:space="preserve"><value>Top Edge</value></data>
+<data name="SkewCenterPointBottom" xml:space="preserve"><value>Bottom Edge</value></data>
+<data name="SkewCenterPointLeft" xml:space="preserve"><value>Left Edge</value></data>
+<data name="SkewCenterPointRight" xml:space="preserve"><value>Right Edge</value></data>
+<data name="SkewCenterPointCustom" xml:space="preserve"><value>Custom</value></data>
+<data name="CenterX" xml:space="preserve"><value>Center X</value></data>
+<data name="CenterXDesc" xml:space="preserve"><value>Center of Transformation X</value></data>
+<data name="CenterY" xml:space="preserve"><value>Center Y</value></data>
+<data name="CenterYDesc" xml:space="preserve"><value>Center of Transformation Y</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.es-es.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.es-es.resx
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>es-es</value></data>
+<data name="AudioVolumeSkewEffect" xml:space="preserve"><value>Transformación de sesgado según el volumen</value></data>
+<data name="AngleX" xml:space="preserve"><value>Dirección X</value></data>
+<data name="AngleXDesc" xml:space="preserve"><value>Ángulo en la dirección X</value></data>
+<data name="AngleY" xml:space="preserve"><value>Dirección Y</value></data>
+<data name="AngleYDesc" xml:space="preserve"><value>Ángulo en la dirección Y</value></data>
+<data name="CenterPoint" xml:space="preserve"><value>Centro</value></data>
+<data name="CenterPointDesc" xml:space="preserve"><value>Centro de transformación</value></data>
+<data name="SkewCenterPointCenter" xml:space="preserve"><value>Centro</value></data>
+<data name="SkewCenterPointTop" xml:space="preserve"><value>Borde superior</value></data>
+<data name="SkewCenterPointBottom" xml:space="preserve"><value>Borde inferior</value></data>
+<data name="SkewCenterPointLeft" xml:space="preserve"><value>Borde izquierdo</value></data>
+<data name="SkewCenterPointRight" xml:space="preserve"><value>Borde derecho</value></data>
+<data name="SkewCenterPointCustom" xml:space="preserve"><value>Personalizado</value></data>
+<data name="CenterX" xml:space="preserve"><value>Centro X</value></data>
+<data name="CenterXDesc" xml:space="preserve"><value>Centro de transformación X</value></data>
+<data name="CenterY" xml:space="preserve"><value>Centro Y</value></data>
+<data name="CenterYDesc" xml:space="preserve"><value>Centro de transformación Y</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.id-id.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.id-id.resx
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>id-id</value></data>
+<data name="AudioVolumeSkewEffect" xml:space="preserve"><value>Transformasi Miring Sesuai Volume</value></data>
+<data name="AngleX" xml:space="preserve"><value>Arah X</value></data>
+<data name="AngleXDesc" xml:space="preserve"><value>Sudut Arah X</value></data>
+<data name="AngleY" xml:space="preserve"><value>Arah Y</value></data>
+<data name="AngleYDesc" xml:space="preserve"><value>Sudut Arah Y</value></data>
+<data name="CenterPoint" xml:space="preserve"><value>Pusat</value></data>
+<data name="CenterPointDesc" xml:space="preserve"><value>Pusat Transformasi</value></data>
+<data name="SkewCenterPointCenter" xml:space="preserve"><value>Tengah</value></data>
+<data name="SkewCenterPointTop" xml:space="preserve"><value>Tepi Atas</value></data>
+<data name="SkewCenterPointBottom" xml:space="preserve"><value>Tepi Bawah</value></data>
+<data name="SkewCenterPointLeft" xml:space="preserve"><value>Tepi Kiri</value></data>
+<data name="SkewCenterPointRight" xml:space="preserve"><value>Tepi Kanan</value></data>
+<data name="SkewCenterPointCustom" xml:space="preserve"><value>Kustom</value></data>
+<data name="CenterX" xml:space="preserve"><value>Tengah X</value></data>
+<data name="CenterXDesc" xml:space="preserve"><value>Pusat Transformasi X</value></data>
+<data name="CenterY" xml:space="preserve"><value>Tengah Y</value></data>
+<data name="CenterYDesc" xml:space="preserve"><value>Pusat Transformasi Y</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.ko-kr.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.ko-kr.resx
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ko-kr</value></data>
+<data name="AudioVolumeSkewEffect" xml:space="preserve"><value>음량에 따라 기울기 변형</value></data>
+<data name="AngleX" xml:space="preserve"><value>X 방향</value></data>
+<data name="AngleXDesc" xml:space="preserve"><value>X 방향의 각도</value></data>
+<data name="AngleY" xml:space="preserve"><value>Y 방향</value></data>
+<data name="AngleYDesc" xml:space="preserve"><value>Y 방향의 각도</value></data>
+<data name="CenterPoint" xml:space="preserve"><value>중심</value></data>
+<data name="CenterPointDesc" xml:space="preserve"><value>변형의 중심</value></data>
+<data name="SkewCenterPointCenter" xml:space="preserve"><value>중앙</value></data>
+<data name="SkewCenterPointTop" xml:space="preserve"><value>윗변</value></data>
+<data name="SkewCenterPointBottom" xml:space="preserve"><value>아랫변</value></data>
+<data name="SkewCenterPointLeft" xml:space="preserve"><value>왼쪽 변</value></data>
+<data name="SkewCenterPointRight" xml:space="preserve"><value>오른쪽 변</value></data>
+<data name="SkewCenterPointCustom" xml:space="preserve"><value>커스텀</value></data>
+<data name="CenterX" xml:space="preserve"><value>중심 X</value></data>
+<data name="CenterXDesc" xml:space="preserve"><value>변형의 중심 X</value></data>
+<data name="CenterY" xml:space="preserve"><value>중심 Y</value></data>
+<data name="CenterYDesc" xml:space="preserve"><value>변형의 중심 Y</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.resx
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ja-jp</value></data>
+<data name="AudioVolumeSkewEffect" xml:space="preserve"><value>音量に合わせて傾斜変形</value></data>
+<data name="AngleX" xml:space="preserve"><value>X方向</value></data>
+<data name="AngleXDesc" xml:space="preserve"><value>X方向の角度</value></data>
+<data name="AngleY" xml:space="preserve"><value>Y方向</value></data>
+<data name="AngleYDesc" xml:space="preserve"><value>Y方向の角度</value></data>
+<data name="CenterPoint" xml:space="preserve"><value>中心</value></data>
+<data name="CenterPointDesc" xml:space="preserve"><value>変形の中心</value></data>
+<data name="SkewCenterPointCenter" xml:space="preserve"><value>中央</value></data>
+<data name="SkewCenterPointTop" xml:space="preserve"><value>上辺</value></data>
+<data name="SkewCenterPointBottom" xml:space="preserve"><value>下辺</value></data>
+<data name="SkewCenterPointLeft" xml:space="preserve"><value>左辺</value></data>
+<data name="SkewCenterPointRight" xml:space="preserve"><value>右辺</value></data>
+<data name="SkewCenterPointCustom" xml:space="preserve"><value>カスタム</value></data>
+<data name="CenterX" xml:space="preserve"><value>中心X</value></data>
+<data name="CenterXDesc" xml:space="preserve"><value>変形の中心X</value></data>
+<data name="CenterY" xml:space="preserve"><value>中心Y</value></data>
+<data name="CenterYDesc" xml:space="preserve"><value>変形の中心Y</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.zh-cn.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.zh-cn.resx
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-cn</value></data>
+<data name="AudioVolumeSkewEffect" xml:space="preserve"><value>根据音量进行倾斜变形</value></data>
+<data name="AngleX" xml:space="preserve"><value>X方向</value></data>
+<data name="AngleXDesc" xml:space="preserve"><value>X方向的角度</value></data>
+<data name="AngleY" xml:space="preserve"><value>Y方向</value></data>
+<data name="AngleYDesc" xml:space="preserve"><value>Y方向的角度</value></data>
+<data name="CenterPoint" xml:space="preserve"><value>中心</value></data>
+<data name="CenterPointDesc" xml:space="preserve"><value>变形中心</value></data>
+<data name="SkewCenterPointCenter" xml:space="preserve"><value>中央</value></data>
+<data name="SkewCenterPointTop" xml:space="preserve"><value>上边</value></data>
+<data name="SkewCenterPointBottom" xml:space="preserve"><value>下边</value></data>
+<data name="SkewCenterPointLeft" xml:space="preserve"><value>左边</value></data>
+<data name="SkewCenterPointRight" xml:space="preserve"><value>右边</value></data>
+<data name="SkewCenterPointCustom" xml:space="preserve"><value>自定义</value></data>
+<data name="CenterX" xml:space="preserve"><value>中心X</value></data>
+<data name="CenterXDesc" xml:space="preserve"><value>变形中心X</value></data>
+<data name="CenterY" xml:space="preserve"><value>中心Y</value></data>
+<data name="CenterYDesc" xml:space="preserve"><value>变形中心Y</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.zh-tw.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Skew/Texts.zh-tw.resx
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-tw</value></data>
+<data name="AudioVolumeSkewEffect" xml:space="preserve"><value>根據音量進行傾斜變形</value></data>
+<data name="AngleX" xml:space="preserve"><value>X方向</value></data>
+<data name="AngleXDesc" xml:space="preserve"><value>X方向的角度</value></data>
+<data name="AngleY" xml:space="preserve"><value>Y方向</value></data>
+<data name="AngleYDesc" xml:space="preserve"><value>Y方向的角度</value></data>
+<data name="CenterPoint" xml:space="preserve"><value>中心</value></data>
+<data name="CenterPointDesc" xml:space="preserve"><value>變形中心</value></data>
+<data name="SkewCenterPointCenter" xml:space="preserve"><value>中央</value></data>
+<data name="SkewCenterPointTop" xml:space="preserve"><value>上邊</value></data>
+<data name="SkewCenterPointBottom" xml:space="preserve"><value>下邊</value></data>
+<data name="SkewCenterPointLeft" xml:space="preserve"><value>左邊</value></data>
+<data name="SkewCenterPointRight" xml:space="preserve"><value>右邊</value></data>
+<data name="SkewCenterPointCustom" xml:space="preserve"><value>自訂</value></data>
+<data name="CenterX" xml:space="preserve"><value>中心X</value></data>
+<data name="CenterXDesc" xml:space="preserve"><value>變形中心X</value></data>
+<data name="CenterY" xml:space="preserve"><value>中心Y</value></data>
+<data name="CenterYDesc" xml:space="preserve"><value>變形中心Y</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/AudioVolumeZoomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/AudioVolumeZoomEffect.cs
@@ -1,0 +1,40 @@
+﻿using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase;
+using YukkuriMovieMaker.Plugin.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Zoom
+{
+    [VideoEffect(nameof(Texts.AudioVolumeZoomEffect), [VideoEffectCategories.Animation], ["audio volume zoom"], IsAviUtlSupported = false, IsEffectItemSupported = false, ResourceType = typeof(Texts))]
+    internal class AudioVolumeZoomEffect : AudioVolumeVideoEffectBase
+    {
+        public override string Label => $"{Texts.AudioVolumeZoomEffect} X{ZoomX.GetValue(0, 1, 30) * Zoom.GetValue(0, 1, 30) / 100.0:F0}%, Y{ZoomY.GetValue(0, 1, 30) * Zoom.GetValue(0, 1, 30) / 100.0:F0}%";
+
+        [Display(GroupName = nameof(Texts.AudioVolumeZoomEffect), Name = nameof(Texts.Zoom), Description = nameof(Texts.ZoomDesc),  ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0.0, 500.0)]
+        public Animation Zoom { get; } = new Animation(150.0, 0.0, 800.0);
+
+        [Display(GroupName = nameof(Texts.AudioVolumeZoomEffect), Name = nameof(Texts.ZoomX), Description = nameof(Texts.ZoomXDesc), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0.0, 500.0)]
+        public Animation ZoomX { get; } = new Animation(100.0, 0.0, 800.0);
+
+        [Display(GroupName = nameof(Texts.AudioVolumeZoomEffect), Name = nameof(Texts.ZoomY), Description = nameof(Texts.ZoomY), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0.0, 500.0)]
+        public Animation ZoomY { get; } = new Animation(100.0, 0.0, 800.0);
+
+        public override IEnumerable<string> CreateExoVideoFilters(int keyFrameIndex, ExoOutputDescription exoOutputDescription)
+        {
+            return [];
+        }
+
+        public override IVideoEffectProcessor CreateVideoEffect(IGraphicsDevicesAndContext devices)
+        {
+            return new AudioVolumeZoomEffectProcessor(devices, this);
+        }
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [Zoom, ZoomX, ZoomY, ..base.GetAnimatables()];
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/AudioVolumeZoomEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/AudioVolumeZoomEffectProcessor.cs
@@ -1,0 +1,41 @@
+﻿using System.Numerics;
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Commons.EffectBase;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Zoom
+{
+    internal class AudioVolumeZoomEffectProcessor(IGraphicsDevicesAndContext devices, AudioVolumeZoomEffect item) : AudioVolumeVideoEffectProcessorBase(devices, item)
+    {
+        public override DrawDescription Update(EffectDescription effectDescription, double audioVolume)
+        {
+            var frame = effectDescription.ItemPosition.Frame;
+            var length = effectDescription.ItemDuration.Frame;
+            var fps = effectDescription.FPS;
+
+            var zoom = (float)(item.Zoom.GetValue(frame, length, fps) / 100.0);
+            var zoomX = (float)(item.ZoomX.GetValue(frame, length, fps) / 100.0);
+            var zoomY = (float)(item.ZoomY.GetValue(frame, length, fps) / 100.0);
+
+            var drawDescription = effectDescription.DrawDescription;
+            return drawDescription with
+            {
+                Zoom = drawDescription.Zoom * (new Vector2(zoomY, zoomX) * zoom * (float)audioVolume + new Vector2(1, 1) * (1 - (float)audioVolume))
+            };
+        }
+
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            return null;
+        }
+
+        protected override void setInput(ID2D1Image? input)
+        {
+        }
+
+        protected override void ClearEffectChain()
+        {
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.ar-sa.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.ar-sa.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ar-sa</value></data>
+<data name="AudioVolumeZoomEffect" xml:space="preserve"><value>التحجيم حسب مستوى الصوت</value></data>
+<data name="Zoom" xml:space="preserve"><value>الكل</value></data>
+<data name="ZoomDesc" xml:space="preserve"><value>معدل التكبير الكلي</value></data>
+<data name="ZoomX" xml:space="preserve"><value>الاتجاه الأفقي</value></data>
+<data name="ZoomXDesc" xml:space="preserve"><value>معدل التحجيم في اتجاه المحور X</value></data>
+<data name="ZoomY" xml:space="preserve"><value>الاتجاه العمودي</value></data>
+<data name="ZoomYDesc" xml:space="preserve"><value>معدل التحجيم في اتجاه المحور Y</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.cs
@@ -1,0 +1,9 @@
+﻿using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AudioVolume.Zoom
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.csv
@@ -1,0 +1,8 @@
+﻿Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+AudioVolumeZoomEffect,,音量に合わせて拡大縮小,Scale According to Volume,根据音量缩放,根據音量縮放,음량에 따라 확대/축소,Escalar según el volumen,التحجيم حسب مستوى الصوت,Skala Sesuai Volume
+Zoom,,全体,Whole,整体,整體,전체,Todo,الكل,Keseluruhan
+ZoomDesc,,全体の拡大率,Overall Scale,整体缩放率,整體縮放率,전체 확대율,Escala general,معدل التكبير الكلي,Skala Keseluruhan
+ZoomX,,横方向,Horizontal Direction,水平方向,水平方向,수평 방향,Dirección horizontal,الاتجاه الأفقي,Arah Horizontal
+ZoomXDesc,,X軸方向の拡大率,Scale in X Axis Direction,X轴方向的缩放率,X軸方向的縮放率,X축 방향 확대율,Escala en la dirección del eje X,معدل التحجيم في اتجاه المحور X,Skala Arah Sumbu X
+ZoomY,,縦方向,Vertical Direction,垂直方向,垂直方向,수직 방향,Dirección vertical,الاتجاه العمودي,Arah Vertikal
+ZoomYDesc,,Y軸方向の拡大率,Scale in Y Axis Direction,Y轴方向的缩放率,Y軸方向的縮放率,Y축 방향 확대율,Escala en la dirección del eje Y,معدل التحجيم في اتجاه المحور Y,Skala Arah Sumbu Y

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.en-us.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.en-us.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>en-us</value></data>
+<data name="AudioVolumeZoomEffect" xml:space="preserve"><value>Scale According to Volume</value></data>
+<data name="Zoom" xml:space="preserve"><value>Whole</value></data>
+<data name="ZoomDesc" xml:space="preserve"><value>Overall Scale</value></data>
+<data name="ZoomX" xml:space="preserve"><value>Horizontal Direction</value></data>
+<data name="ZoomXDesc" xml:space="preserve"><value>Scale in X Axis Direction</value></data>
+<data name="ZoomY" xml:space="preserve"><value>Vertical Direction</value></data>
+<data name="ZoomYDesc" xml:space="preserve"><value>Scale in Y Axis Direction</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.es-es.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.es-es.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>es-es</value></data>
+<data name="AudioVolumeZoomEffect" xml:space="preserve"><value>Escalar según el volumen</value></data>
+<data name="Zoom" xml:space="preserve"><value>Todo</value></data>
+<data name="ZoomDesc" xml:space="preserve"><value>Escala general</value></data>
+<data name="ZoomX" xml:space="preserve"><value>Dirección horizontal</value></data>
+<data name="ZoomXDesc" xml:space="preserve"><value>Escala en la dirección del eje X</value></data>
+<data name="ZoomY" xml:space="preserve"><value>Dirección vertical</value></data>
+<data name="ZoomYDesc" xml:space="preserve"><value>Escala en la dirección del eje Y</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.id-id.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.id-id.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>id-id</value></data>
+<data name="AudioVolumeZoomEffect" xml:space="preserve"><value>Skala Sesuai Volume</value></data>
+<data name="Zoom" xml:space="preserve"><value>Keseluruhan</value></data>
+<data name="ZoomDesc" xml:space="preserve"><value>Skala Keseluruhan</value></data>
+<data name="ZoomX" xml:space="preserve"><value>Arah Horizontal</value></data>
+<data name="ZoomXDesc" xml:space="preserve"><value>Skala Arah Sumbu X</value></data>
+<data name="ZoomY" xml:space="preserve"><value>Arah Vertikal</value></data>
+<data name="ZoomYDesc" xml:space="preserve"><value>Skala Arah Sumbu Y</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.ko-kr.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.ko-kr.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ko-kr</value></data>
+<data name="AudioVolumeZoomEffect" xml:space="preserve"><value>음량에 따라 확대/축소</value></data>
+<data name="Zoom" xml:space="preserve"><value>전체</value></data>
+<data name="ZoomDesc" xml:space="preserve"><value>전체 확대율</value></data>
+<data name="ZoomX" xml:space="preserve"><value>수평 방향</value></data>
+<data name="ZoomXDesc" xml:space="preserve"><value>X축 방향 확대율</value></data>
+<data name="ZoomY" xml:space="preserve"><value>수직 방향</value></data>
+<data name="ZoomYDesc" xml:space="preserve"><value>Y축 방향 확대율</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>ja-jp</value></data>
+<data name="AudioVolumeZoomEffect" xml:space="preserve"><value>音量に合わせて拡大縮小</value></data>
+<data name="Zoom" xml:space="preserve"><value>全体</value></data>
+<data name="ZoomDesc" xml:space="preserve"><value>全体の拡大率</value></data>
+<data name="ZoomX" xml:space="preserve"><value>横方向</value></data>
+<data name="ZoomXDesc" xml:space="preserve"><value>X軸方向の拡大率</value></data>
+<data name="ZoomY" xml:space="preserve"><value>縦方向</value></data>
+<data name="ZoomYDesc" xml:space="preserve"><value>Y軸方向の拡大率</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.zh-cn.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.zh-cn.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-cn</value></data>
+<data name="AudioVolumeZoomEffect" xml:space="preserve"><value>根据音量缩放</value></data>
+<data name="Zoom" xml:space="preserve"><value>整体</value></data>
+<data name="ZoomDesc" xml:space="preserve"><value>整体缩放率</value></data>
+<data name="ZoomX" xml:space="preserve"><value>水平方向</value></data>
+<data name="ZoomXDesc" xml:space="preserve"><value>X轴方向的缩放率</value></data>
+<data name="ZoomY" xml:space="preserve"><value>垂直方向</value></data>
+<data name="ZoomYDesc" xml:space="preserve"><value>Y轴方向的缩放率</value></data>
+</root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.zh-tw.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AudioVolume/Zoom/Texts.zh-tw.resx
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+<data name="CurrentCulture" xml:space="preserve"><value>zh-tw</value></data>
+<data name="AudioVolumeZoomEffect" xml:space="preserve"><value>根據音量縮放</value></data>
+<data name="Zoom" xml:space="preserve"><value>整體</value></data>
+<data name="ZoomDesc" xml:space="preserve"><value>整體縮放率</value></data>
+<data name="ZoomX" xml:space="preserve"><value>水平方向</value></data>
+<data name="ZoomXDesc" xml:space="preserve"><value>X軸方向的縮放率</value></data>
+<data name="ZoomY" xml:space="preserve"><value>垂直方向</value></data>
+<data name="ZoomYDesc" xml:space="preserve"><value>Y軸方向的縮放率</value></data>
+</root>


### PR DESCRIPTION
タイムライン、シーン、音声ファイルの音量(RMS)を取得する映像エフェクトを追加しました。
これ以降追加する音量取得エフェクトの処理を共通化するためのクラスも追加しています。

### 追加したエフェクト

- 音量に合わせて移動
- 音量に合わせて回転
- 音量に合わせて拡大縮小
- 音量に合わせて傾斜変形
- 音量に合わせて透過


### 音量取得処理の共通化のためのクラス

- AudioVolumeCalculater 
音量取得に使用するコントロール。
- AudioVolumeCalculaterSource
音声を取得し、音量を計算する。
AudioVolumeCalculater.CreateSource()からインスタンスを生成する。
- AudioVolumeVideoEffectBase
AudioVolumeCalculaterを映像エフェクトで利用する際に使用するVideoEffectBaseを継承した抽象クラス。
- AudioVolumeVideoEffectProcessorBase 
AudioVolumeCalculaterSourceを映像エフェクトで利用する際に使用するVideoEffectProcessorBaseを継承した抽象クラス。