### PR TITLE
拡大縮小（ピクセル）エフェクトの補完モードを修正

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/ZoomPixel/ZoomPixelEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/ZoomPixel/ZoomPixelEffectProcessor.cs
@@ -27,7 +27,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.ZoomPixel
             return effectDescription.DrawDescription with
             {
                 Zoom = item.Size.GetZoom(width, height, effectDescription),
-                ZoomInterpolationMode = item.Dot ? InterpolationMode.NearestNeighbor : effectDescription.DrawDescription.ZoomInterpolationMode,
+                ZoomInterpolationMode = item.Dot ? InterpolationMode.NearestNeighbor : InterpolationMode.HighQualityCubic,
             };
         }
 


### PR DESCRIPTION
### ドット絵を無効にした際の挙動を変更しました。
通常の拡大縮小エフェクトと仕様を統一させるための変更です。

> 変更前の挙動
Updateメソッドの引数から得た補完モードを引継ぎ利用。

> 変更後の挙動
強制的に補完モードをHighQualityCubicに変更。