### PR TITLE
グリッチノイズエフェクトに発生率パラメータを追加

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/RectangleGlitchNoiseEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/RectangleGlitchNoiseEffect.cs
@@ -40,6 +40,10 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.RectangleGlitchNoise
         [AnimationSlider("F1", "%", 0, 100)]
         public Animation PlaybackRate { get; } = new Animation(30, 0, 100);
 
+        [Display(GroupName = nameof(Texts.RectangleGlitchNoise), Name = nameof(Texts.Probability), Description = nameof(Texts.ProbabilityDesc), ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 100)]
+        public Animation Probability { get; } = new Animation(100, 0, 100);
+
         [Display(GroupName = nameof(Texts.RectangleGlitchNoise), Name = nameof(Texts.IsClipping), Description = nameof(Texts.IsClipping), ResourceType = typeof(Texts))]
         [ToggleSlider]
         public bool IsClipping { get => isClipping; set => Set(ref isClipping, value); }
@@ -109,6 +113,6 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.RectangleGlitchNoise
             return new RectangleGlitchNoiseEffectProcessor(devices, this);
         }
 
-        protected override IEnumerable<IAnimatable> GetAnimatables() => [RectangleCount, RectangleMaxWidth, RectangleMaxHeight, RectangleMaxXShift, RectangleMaxYShift, ColorMaxShift, PlaybackRate, Repeat, RectangleMaxWidthAttenuation, RectangleMaxHeightAttenuation, RectangleMaxXShiftAttenuation, RectangleMaxYShiftAttenuation];
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [RectangleCount, RectangleMaxWidth, RectangleMaxHeight, RectangleMaxXShift, RectangleMaxYShift, ColorMaxShift, PlaybackRate, Probability, Repeat, RectangleMaxWidthAttenuation, RectangleMaxHeightAttenuation, RectangleMaxXShiftAttenuation, RectangleMaxYShiftAttenuation];
     }
 }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/RectangleGlitchNoiseEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/RectangleGlitchNoiseEffectProcessor.cs
@@ -1,4 +1,5 @@
-﻿using Vortice.Direct2D1;
+﻿using MathNet.Numerics.Random;
+using Vortice.Direct2D1;
 using YukkuriMovieMaker.Commons;
 using YukkuriMovieMaker.Player.Video;
 using YukkuriMovieMaker.Player.Video.Effects;
@@ -24,26 +25,30 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.RectangleGlitchNoise
             var fps = effectDescription.FPS;
 
             var playbackRate = item.PlaybackRate.GetValue(frame, length, fps);
+            var probability = item.Probability.GetValue(frame, length, fps);
             var seed = item.GetHashCode() % 1000 + (int)(frame * playbackRate / 100);
+
+            bool isEnable = new MersenneTwister(seed).NextDouble() <= probability / 100;
+
             var bounds = devices.DeviceContext.GetImageLocalBounds(input);
             var inputTop = bounds.Top;
             var inputLeft = bounds.Left;
             var inputWidth = bounds.Right - bounds.Left;
             var inputHeight = bounds.Bottom - bounds.Top;
-            var rectangleCount = (int)item.RectangleCount.GetValue(frame, length, fps);
-            var rectangleMaxWidth = (float)item.RectangleMaxWidth.GetValue(frame, length, fps);
-            var rectangleMaxHeight = (float)item.RectangleMaxHeight.GetValue(frame, length, fps);
-            var rectangleMaxXShift = (float)item.RectangleMaxXShift.GetValue(frame, length, fps);
-            var rectangleMaxYShift = (float)item.RectangleMaxYShift.GetValue(frame, length, fps);
-            var colorMaxShift = (float)item.ColorMaxShift.GetValue(frame, length, fps);
+            var rectangleCount = isEnable ? (int)item.RectangleCount.GetValue(frame, length, fps) : 0;
+            var rectangleMaxWidth = isEnable ? (float)item.RectangleMaxWidth.GetValue(frame, length, fps) : 0;
+            var rectangleMaxHeight = isEnable ? (float)item.RectangleMaxHeight.GetValue(frame, length, fps) : 0;
+            var rectangleMaxXShift = isEnable ? (float)item.RectangleMaxXShift.GetValue(frame, length, fps) : 0;
+            var rectangleMaxYShift = isEnable ? (float)item.RectangleMaxYShift.GetValue(frame, length, fps) : 0;
+            var colorMaxShift = isEnable ? (float)item.ColorMaxShift.GetValue(frame, length, fps) : 0;
             var isClipping = item.IsClipping;
             var isHardBorder = item.IsHardBorderMode;
 
-            var repeat = (int)item.Repeat.GetValue(frame, length, fps);
-            var rectangleMaxWidthAttenuation = (float)item.RectangleMaxWidthAttenuation.GetValue(frame, length, fps) / 100;
-            var rectangleMaxHeightAttenuation = (float)item.RectangleMaxHeightAttenuation.GetValue(frame, length, fps) / 100;
-            var rectangleMaxXShiftAttenuation = (float)item.RectangleMaxXShiftAttenuation.GetValue(frame, length, fps) / 100;
-            var rectangleMaxYShiftAttenuation = (float)item.RectangleMaxYShiftAttenuation.GetValue(frame, length, fps) / 100;
+            var repeat = isEnable ? (int)item.Repeat.GetValue(frame, length, fps) : 0;
+            var rectangleMaxWidthAttenuation = isEnable ? (float)item.RectangleMaxWidthAttenuation.GetValue(frame, length, fps) / 100 : 0;
+            var rectangleMaxHeightAttenuation = isEnable ? (float)item.RectangleMaxHeightAttenuation.GetValue(frame, length, fps) / 100 : 0;
+            var rectangleMaxXShiftAttenuation = isEnable ? (float)item.RectangleMaxXShiftAttenuation.GetValue(frame, length, fps) / 100 : 0;
+            var rectangleMaxYShiftAttenuation = isEnable ? (float)item.RectangleMaxYShiftAttenuation.GetValue(frame, length, fps) / 100 : 0;
 
             if (isFirst || this.seed != seed)
                 effect.Seed = seed;

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.ar-sa.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.ar-sa.resx
@@ -76,4 +76,6 @@
 <data name="RectangleMaxHeightAttenuation" xml:space="preserve"><value>تخفيف الارتفاع</value></data>
 <data name="RectangleMaxXShiftAttenuation" xml:space="preserve"><value>تخفيف الانحراف الأفقي</value></data>
 <data name="RectangleMaxYShiftAttenuation" xml:space="preserve"><value>تخفيف الانحراف العمودي</value></data>
+<data name="Probability" xml:space="preserve"><value>معدل الحدوث</value></data>
+<data name="ProbabilityDesc" xml:space="preserve"><value>احتمالية حدوث ضوضاء خلل</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.csv
@@ -16,3 +16,5 @@ RectangleMaxWidthAttenuation,,幅減衰,Width Attenuation,宽度衰减,寬度衰
 RectangleMaxHeightAttenuation,,高さ減衰,Height Attenuation,高度衰减,高度衰減,높이 감쇠,Atenuación de altura,تخفيف الارتفاع,Attenuasi Tinggi,
 RectangleMaxXShiftAttenuation,,横ずれ減衰,Horizontal Shift Attenuation,横向偏移衰减,橫向偏移衰減,가로 이동 감쇠,Atenuación del desplazamiento horizontal,تخفيف الانحراف الأفقي,Attenuasi Perpindahan Horizontal,
 RectangleMaxYShiftAttenuation,,縦ずれ減衰,Vertical Shift Attenuation,纵向偏移衰减,縱向偏移衰減,세로 이동 감쇠,Atenuación del desplazamiento vertical,تخفيف الانحراف العمودي,Attenuasi Perpindahan Vertikal,
+Probability,,発生率,Occurrence Rate,发生率,發生率,발생률,Tasa de ocurrencia,معدل الحدوث,Laju Kejadian
+ProbabilityDesc,,グリッチノイズが発生する確率,Probability of Glitch Noise Occurrence,故障噪音发生的概率,故障噪音發生的機率,글리치 노이즈 발생 확률,Probabilidad de que ocurra ruido de falla,احتمالية حدوث ضوضاء خلل,Kemungkinan Terjadinya Glitch Noise

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.en-us.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.en-us.resx
@@ -76,4 +76,6 @@
 <data name="RectangleMaxHeightAttenuation" xml:space="preserve"><value>Height Attenuation</value></data>
 <data name="RectangleMaxXShiftAttenuation" xml:space="preserve"><value>Horizontal Shift Attenuation</value></data>
 <data name="RectangleMaxYShiftAttenuation" xml:space="preserve"><value>Vertical Shift Attenuation</value></data>
+<data name="Probability" xml:space="preserve"><value>Occurrence Rate</value></data>
+<data name="ProbabilityDesc" xml:space="preserve"><value>Probability of Glitch Noise Occurrence</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.es-es.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.es-es.resx
@@ -76,4 +76,6 @@
 <data name="RectangleMaxHeightAttenuation" xml:space="preserve"><value>Atenuación de altura</value></data>
 <data name="RectangleMaxXShiftAttenuation" xml:space="preserve"><value>Atenuación del desplazamiento horizontal</value></data>
 <data name="RectangleMaxYShiftAttenuation" xml:space="preserve"><value>Atenuación del desplazamiento vertical</value></data>
+<data name="Probability" xml:space="preserve"><value>Tasa de ocurrencia</value></data>
+<data name="ProbabilityDesc" xml:space="preserve"><value>Probabilidad de que ocurra ruido de falla</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.id-id.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.id-id.resx
@@ -76,4 +76,6 @@
 <data name="RectangleMaxHeightAttenuation" xml:space="preserve"><value>Attenuasi Tinggi</value></data>
 <data name="RectangleMaxXShiftAttenuation" xml:space="preserve"><value>Attenuasi Perpindahan Horizontal</value></data>
 <data name="RectangleMaxYShiftAttenuation" xml:space="preserve"><value>Attenuasi Perpindahan Vertikal</value></data>
+<data name="Probability" xml:space="preserve"><value>Laju Kejadian</value></data>
+<data name="ProbabilityDesc" xml:space="preserve"><value>Kemungkinan Terjadinya Glitch Noise</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.ko-kr.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.ko-kr.resx
@@ -76,4 +76,6 @@
 <data name="RectangleMaxHeightAttenuation" xml:space="preserve"><value>높이 감쇠</value></data>
 <data name="RectangleMaxXShiftAttenuation" xml:space="preserve"><value>가로 이동 감쇠</value></data>
 <data name="RectangleMaxYShiftAttenuation" xml:space="preserve"><value>세로 이동 감쇠</value></data>
+<data name="Probability" xml:space="preserve"><value>발생률</value></data>
+<data name="ProbabilityDesc" xml:space="preserve"><value>글리치 노이즈 발생 확률</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.resx
@@ -76,4 +76,6 @@
 <data name="RectangleMaxHeightAttenuation" xml:space="preserve"><value>高さ減衰</value></data>
 <data name="RectangleMaxXShiftAttenuation" xml:space="preserve"><value>横ずれ減衰</value></data>
 <data name="RectangleMaxYShiftAttenuation" xml:space="preserve"><value>縦ずれ減衰</value></data>
+<data name="Probability" xml:space="preserve"><value>発生率</value></data>
+<data name="ProbabilityDesc" xml:space="preserve"><value>グリッチノイズが発生する確率</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.zh-cn.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.zh-cn.resx
@@ -76,4 +76,6 @@
 <data name="RectangleMaxHeightAttenuation" xml:space="preserve"><value>高度衰减</value></data>
 <data name="RectangleMaxXShiftAttenuation" xml:space="preserve"><value>横向偏移衰减</value></data>
 <data name="RectangleMaxYShiftAttenuation" xml:space="preserve"><value>纵向偏移衰减</value></data>
+<data name="Probability" xml:space="preserve"><value>发生率</value></data>
+<data name="ProbabilityDesc" xml:space="preserve"><value>故障噪音发生的概率</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.zh-tw.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/RectangleGlitchNoise/Texts.zh-tw.resx
@@ -76,4 +76,6 @@
 <data name="RectangleMaxHeightAttenuation" xml:space="preserve"><value>高度衰減</value></data>
 <data name="RectangleMaxXShiftAttenuation" xml:space="preserve"><value>橫向偏移衰減</value></data>
 <data name="RectangleMaxYShiftAttenuation" xml:space="preserve"><value>縱向偏移衰減</value></data>
+<data name="Probability" xml:space="preserve"><value>發生率</value></data>
+<data name="ProbabilityDesc" xml:space="preserve"><value>故障噪音發生的機率</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/StripeGlitchNoiseEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/StripeGlitchNoiseEffect.cs
@@ -32,6 +32,10 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.StripeGlitchNoise
         [AnimationSlider("F1", "%", 0, 100)]
         public Animation PlaybackRate { get; } = new Animation(30, 0, 100);
 
+        [Display(GroupName = nameof(Texts.StripeGlitchNoiseEffectName), Name = nameof(Texts.StripeGlitchNoiseEffectProbability), Description = nameof(Texts.StripeGlitchNoiseEffectProbabilityDesc), Order = 100, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 100)]
+        public Animation Probability { get; } = new Animation(100, 0, 100);
+
         [Display(GroupName = nameof(Texts.StripeGlitchNoiseEffectName), Name = nameof(Texts.StripeGlitchNoiseEffectIsHardBorderModeName), Description = nameof(Texts.StripeGlitchNoiseEffectIsHardBorderModeDesc), Order = 100, ResourceType = typeof(Texts))]
         [ToggleSlider]
         public bool IsHardBorderMode { get => isHardBorderMode; set => Set(ref isHardBorderMode, value); }
@@ -76,6 +80,6 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.StripeGlitchNoise
             return new StripeGlitchNoiseEffectProcessor(devices, this);
         }
 
-        protected override IEnumerable<IAnimatable> GetAnimatables() => [StripeCount, StripeMaxWidth, StripeMaxShift, ColorMaxShift, PlaybackRate, Repeat, StripeMaxWidthAttenuation, StripeMaxShiftAttenuation];
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [StripeCount, StripeMaxWidth, StripeMaxShift, ColorMaxShift, PlaybackRate, Probability, Repeat, StripeMaxWidthAttenuation, StripeMaxShiftAttenuation];
     }
 }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/StripeGlitchNoiseEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/StripeGlitchNoiseEffectProcessor.cs
@@ -1,4 +1,5 @@
-﻿using Vortice.Direct2D1;
+﻿using MathNet.Numerics.Random;
+using Vortice.Direct2D1;
 using YukkuriMovieMaker.Commons;
 using YukkuriMovieMaker.Player.Video;
 using YukkuriMovieMaker.Player.Video.Effects;
@@ -24,19 +25,23 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.StripeGlitchNoise
             var fps = effectDescription.FPS;
 
             var playbackRate = item.PlaybackRate.GetValue(frame, length, fps);
+            var probability = item.Probability.GetValue(frame, length, fps);
             var seed = item.GetHashCode() % 1000 + (int)(frame * playbackRate / 100);
+
+            bool isEnable = new MersenneTwister(seed).NextDouble() <= probability / 100;
+
             var bounds = devices.DeviceContext.GetImageLocalBounds(input);
             var inputTop = bounds.Top;
             var inputHeight = bounds.Bottom - bounds.Top;
-            var stripeCount = (int)item.StripeCount.GetValue(frame, length, fps);
-            var stripeMaxWidth = (float)item.StripeMaxWidth.GetValue(frame, length, fps);
-            var stripeMaxShift = (float)item.StripeMaxShift.GetValue(frame, length, fps);
-            var colorMaxShift = (float)item.ColorMaxShift.GetValue(frame, length, fps);
+            var stripeCount = isEnable ? (int)item.StripeCount.GetValue(frame, length, fps) : 0;
+            var stripeMaxWidth = isEnable ? (float)item.StripeMaxWidth.GetValue(frame, length, fps) : 0;
+            var stripeMaxShift = isEnable ? (float)item.StripeMaxShift.GetValue(frame, length, fps) : 0;
+            var colorMaxShift = isEnable ? (float)item.ColorMaxShift.GetValue(frame, length, fps) : 0;
             var isHardBorder = item.IsHardBorderMode;
 
-            var repeat = (int)item.Repeat.GetValue(frame, length, fps);
-            var stripeMaxWidthAttenuation = (float)item.StripeMaxWidthAttenuation.GetValue(frame, length, fps) / 100;
-            var stripeMaxShiftAttenuation = (float)item.StripeMaxShiftAttenuation.GetValue(frame, length, fps) / 100;
+            var repeat = isEnable ? (int)item.Repeat.GetValue(frame, length, fps) : 0;
+            var stripeMaxWidthAttenuation = isEnable ? (float)item.StripeMaxWidthAttenuation.GetValue(frame, length, fps) / 100 : 0;
+            var stripeMaxShiftAttenuation = isEnable ? (float)item.StripeMaxShiftAttenuation.GetValue(frame, length, fps) / 100 : 0;
 
             if (isFirst || this.seed != seed)
                 effect.Seed = seed;

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.ar-sa.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.ar-sa.resx
@@ -80,4 +80,6 @@
 <data name="StripeGlitchNoiseEffectComplicationGroupName" xml:space="preserve"><value>التعقيد</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateName" xml:space="preserve"><value>معدل تشغيل الضوضاء المتموجة</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateDesc" xml:space="preserve"><value>معدل تشغيل تأثير ضوضاء خطأ الشريط</value></data>
+<data name="StripeGlitchNoiseEffectProbability" xml:space="preserve"><value>معدل الحدوث</value></data>
+<data name="StripeGlitchNoiseEffectProbabilityDesc" xml:space="preserve"><value>احتمالية حدوث ضوضاء خلل</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.csv
@@ -20,3 +20,5 @@ StripeGlitchNoiseEffectStripeMaxShiftAttenuationDesc,,ずれ減衰,Shift attenua
 StripeGlitchNoiseEffectComplicationGroupName,,複雑化,Complication,复杂化,複雜化,복잡화,Complicación,التعقيد,Komplikasi
 StripeGlitchNoiseEffectPlaybackRateName,,再生速度,Playback rate,播放速度,播放速度,재생 속도,Velocidad de reproducción,"معدل تشغيل الضوضاء المتموجة",Kecepatan pemutaran
 StripeGlitchNoiseEffectPlaybackRateDesc,,再生速度,Playback rate,播放速度,播放速度,재생 속도,Velocidad de reproducción,معدل تشغيل تأثير ضوضاء خطأ الشريط,Kecepatan pemutaran
+StripeGlitchNoiseEffectProbability,,発生率,Occurrence Rate,发生率,發生率,발생률,Tasa de ocurrencia,معدل الحدوث,Laju Kejadian
+StripeGlitchNoiseEffectProbabilityDesc,,グリッチノイズが発生する確率,Probability of Glitch Noise Occurrence,故障噪音发生的概率,故障噪音發生的機率,글리치 노이즈 발생 확률,Probabilidad de que ocurra ruido de falla,احتمالية حدوث ضوضاء خلل,Kemungkinan Terjadinya Glitch Noise

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.en-us.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.en-us.resx
@@ -80,4 +80,6 @@
 <data name="StripeGlitchNoiseEffectComplicationGroupName" xml:space="preserve"><value>Complication</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateName" xml:space="preserve"><value>Playback rate</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateDesc" xml:space="preserve"><value>Playback rate</value></data>
+<data name="StripeGlitchNoiseEffectProbability" xml:space="preserve"><value>Occurrence Rate</value></data>
+<data name="StripeGlitchNoiseEffectProbabilityDesc" xml:space="preserve"><value>Probability of Glitch Noise Occurrence</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.es-es.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.es-es.resx
@@ -80,4 +80,6 @@
 <data name="StripeGlitchNoiseEffectComplicationGroupName" xml:space="preserve"><value>Complicación</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateName" xml:space="preserve"><value>Velocidad de reproducción</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateDesc" xml:space="preserve"><value>Velocidad de reproducción</value></data>
+<data name="StripeGlitchNoiseEffectProbability" xml:space="preserve"><value>Tasa de ocurrencia</value></data>
+<data name="StripeGlitchNoiseEffectProbabilityDesc" xml:space="preserve"><value>Probabilidad de que ocurra ruido de falla</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.id-id.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.id-id.resx
@@ -80,4 +80,6 @@
 <data name="StripeGlitchNoiseEffectComplicationGroupName" xml:space="preserve"><value>Komplikasi</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateName" xml:space="preserve"><value>Kecepatan pemutaran</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateDesc" xml:space="preserve"><value>Kecepatan pemutaran</value></data>
+<data name="StripeGlitchNoiseEffectProbability" xml:space="preserve"><value>Laju Kejadian</value></data>
+<data name="StripeGlitchNoiseEffectProbabilityDesc" xml:space="preserve"><value>Kemungkinan Terjadinya Glitch Noise</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.ko-kr.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.ko-kr.resx
@@ -80,4 +80,6 @@
 <data name="StripeGlitchNoiseEffectComplicationGroupName" xml:space="preserve"><value>복잡화</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateName" xml:space="preserve"><value>재생 속도</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateDesc" xml:space="preserve"><value>재생 속도</value></data>
+<data name="StripeGlitchNoiseEffectProbability" xml:space="preserve"><value>발생률</value></data>
+<data name="StripeGlitchNoiseEffectProbabilityDesc" xml:space="preserve"><value>글리치 노이즈 발생 확률</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.resx
@@ -80,4 +80,6 @@
 <data name="StripeGlitchNoiseEffectComplicationGroupName" xml:space="preserve"><value>複雑化</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateName" xml:space="preserve"><value>再生速度</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateDesc" xml:space="preserve"><value>再生速度</value></data>
+<data name="StripeGlitchNoiseEffectProbability" xml:space="preserve"><value>発生率</value></data>
+<data name="StripeGlitchNoiseEffectProbabilityDesc" xml:space="preserve"><value>グリッチノイズが発生する確率</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.zh-cn.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.zh-cn.resx
@@ -80,4 +80,6 @@
 <data name="StripeGlitchNoiseEffectComplicationGroupName" xml:space="preserve"><value>复杂化</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateName" xml:space="preserve"><value>播放速度</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateDesc" xml:space="preserve"><value>播放速度</value></data>
+<data name="StripeGlitchNoiseEffectProbability" xml:space="preserve"><value>发生率</value></data>
+<data name="StripeGlitchNoiseEffectProbabilityDesc" xml:space="preserve"><value>故障噪音发生的概率</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.zh-tw.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/StripeGlitchNoise/Texts.zh-tw.resx
@@ -80,4 +80,6 @@
 <data name="StripeGlitchNoiseEffectComplicationGroupName" xml:space="preserve"><value>複雜化</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateName" xml:space="preserve"><value>播放速度</value></data>
 <data name="StripeGlitchNoiseEffectPlaybackRateDesc" xml:space="preserve"><value>播放速度</value></data>
+<data name="StripeGlitchNoiseEffectProbability" xml:space="preserve"><value>發生率</value></data>
+<data name="StripeGlitchNoiseEffectProbabilityDesc" xml:space="preserve"><value>故障噪音發生的機率</value></data>
 </root>


### PR DESCRIPTION
グリッチノイズ（帯）とグリッチノイズ（四角形）エフェクトに「発生率」のパラメータを追加しました。

発生率を下げることにより、時々ノイズがチラつくような演出を作ることができます。（デフォルト値は100%なので追加以前のバージョンとの互換性は保たれます）

https://github.com/user-attachments/assets/4a46fbee-da4f-44af-a630-8874b7a59bc3