### PR TITLE
ルミナンスキーカスタムエフェクトのアクセスをpublicに変更

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/LuminanceKey/LuminanceKeyCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/LuminanceKey/LuminanceKeyCustomEffect.cs
@@ -6,7 +6,7 @@ using YukkuriMovieMaker.Plugin.Community.Commons;
 
 namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.LuminanceKey
 {
-    internal class LuminanceKeyCustomEffect(IGraphicsDevicesAndContext devices) : D2D1CustomShaderEffectBase(Create<EffectImpl>(devices))
+    public class LuminanceKeyCustomEffect(IGraphicsDevicesAndContext devices) : D2D1CustomShaderEffectBase(Create<EffectImpl>(devices))
     {
         public float Threshold
         {


### PR DESCRIPTION
LuminanceKeyCustomEffectクラスのアクセス修飾子をpublicにしました。
配布型プラグインからルミナンスキーを利用する為の変更です。