### PR TITLE
プラグインポータルに新しいUIを追加。

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/PluginPortalView.xaml
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/PluginPortalView.xaml
@@ -13,6 +13,7 @@
     <Grid Margin="0">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="200"/>
+            <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
@@ -50,8 +51,6 @@
                             </Style>
                         </TextBlock.Style>
                     </TextBlock>
-
-                    
                 </Grid>
 
                 <c:DropDownButton Grid.Column="1" Content="{DynamicResource menu}" Padding="2" Width="20">
@@ -86,10 +85,14 @@
             </ListBox>
 
             <Button Grid.Row="2" Content="{x:Static local:Texts.InstallDownloaded}" Command="{Binding InstallLocalCommand}" Height="25"/>
-            
         </Grid>
 
-        <Grid Grid.Column="1">
+        <GridSplitter Grid.Column="1"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Stretch"
+                      Width="5"
+                      Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
+        <Grid Grid.Column="2">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
@@ -106,10 +109,18 @@
             </Grid.Style>
 
             <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto" Margin="10">
-                <StackPanel>
-                    <TextBlock Text="{Binding SelectedPlugin.Name}" FontWeight="Bold" FontSize="22" Margin="0,0,0,15"/>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    
+                    <TextBlock Grid.Row="0" Text="{Binding SelectedPlugin.Name}" FontWeight="Bold" FontSize="22" Margin="0,0,0,15"/>
 
-                    <Grid>
+                    <Grid Grid.Row="1">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
@@ -138,11 +149,11 @@
                     </TextBlock>
                     </Grid>
 
-                    <TextBlock Text="{x:Static local:Texts.Description}" FontWeight="Bold" Margin="0,20,0,5"/>
-                    <Separator/>
-                    <TextBlock Text="{Binding SelectedPlugin.Description}" Margin="0,5,0,0"/>
+                    <TextBlock Grid.Row="2" Text="{x:Static local:Texts.Description}" FontWeight="Bold" Margin="0,20,0,5"/>
+                    <Separator Grid.Row="3"/>
+                    <TextBlock Grid.Row="4" Text="{Binding SelectedPlugin.Description}" Margin="0,5,0,0" TextWrapping="Wrap"/>
 
-                </StackPanel>
+                </Grid>
             </ScrollViewer>
 
             <StackPanel Grid.Row="1">

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/PluginPortalViewModel.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/PluginPortalViewModel.cs
@@ -49,7 +49,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.PluginPortal
             get => _searchText;
             set
             {
-                if(_searchText != value)
+                if (_searchText != value)
                 {
                     _searchText = value;
                     OnPropertyChanged(nameof(SearchText));
@@ -296,25 +296,38 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.PluginPortal
             }
 
             var ymmeFiles = Directory.GetFiles(_tempPluginsDir, "*.ymme");
+
             var fileNames = ymmeFiles.Select(Path.GetFileName);
 
-            var messageBuilder = new System.Text.StringBuilder();
-            messageBuilder.AppendLine(Texts.InstallPluginsMessage);
-            messageBuilder.AppendLine();
-            foreach (var name in fileNames)
-            {
-                messageBuilder.AppendLine($" - {name}");
-            }
+            var selectionWindow = new PluginSelectionWindow(ymmeFiles);
+            var dialogResult = selectionWindow.ShowDialog();
 
-            var result = MessageBox.Show(messageBuilder.ToString(), Texts.InstallAllPlugins, MessageBoxButton.YesNo);
+            ((ActionCommand)InstallLocalCommand).RaiseCanExecuteChanged();
 
-            if (result != MessageBoxResult.Yes)
+            if (dialogResult != true)
             {
                 StatusMessage = Texts.CancelBulkInstallation;
                 return;
             }
 
-            LaunchInstaller(_tempPluginsDir, true, PluginPortalSettings.Default.IsCleanYmmeFile);
+            var selectedFiles = selectionWindow.SelectedFiles.ToList();
+            if (selectedFiles.Count == 0)
+            {
+                StatusMessage = Texts.NoPluginsSelected;
+                return;
+            }
+            else if (selectedFiles.Count < ymmeFiles.Length)
+            {
+                foreach (var file in selectedFiles)
+                {
+                    LaunchInstaller(file, false, PluginPortalSettings.Default.IsCleanYmmeFile);
+                }
+            }
+            else
+            {
+                LaunchInstaller(_tempPluginsDir, true, PluginPortalSettings.Default.IsCleanYmmeFile);
+            }
+
 
             if (!PluginPortalSettings.Default.IsCleanYmmeFile)
             {

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/PluginPortalViewModel.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/PluginPortalViewModel.cs
@@ -251,19 +251,18 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.PluginPortal
                     "YukkuriMovieMaker.Plugin.Installer.exe");
 
                 var arguments = new List<string>();
+
                 if (isDirectory)
                 {
-                    arguments.Add($"--dir \"{path}\"");
-                }
-                else
-                {
-                    arguments.Add($"\"{path}\"");
+                    arguments.Add($"--dir");
                 }
 
                 if (cleanAfterInstall)
                 {
                     arguments.Add("--clean");
                 }
+
+                arguments.Add($"\"{path}\"");
 
                 Process.Start(installerPath, string.Join(" ", arguments));
             }

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/PluginSelectionViewModel.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/PluginSelectionViewModel.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Windows;
+using System.Windows.Input;
+using YukkuriMovieMaker.Commons;
+
+namespace YukkuriMovieMaker.Plugin.Community.Tool.PluginPortal
+{
+    internal class PluginSelectionViewModel
+    {
+        public ObservableCollection<SelectablePluginFile> PluginFiles { get; }
+
+        public ICommand DeleteCommand { get; }
+        public ICommand InstallCommand { get; }
+        public ICommand CancelCommand { get; }
+
+        private readonly Action<bool?, IEnumerable<string>> _closeAction;
+
+        public PluginSelectionViewModel(IEnumerable<string> filePaths, Action<bool?, IEnumerable<string>> closeAction)
+        {
+            _closeAction = closeAction;
+            PluginFiles = new ObservableCollection<SelectablePluginFile>(
+                filePaths.Select(path => new SelectablePluginFile(path))
+            );
+
+            InstallCommand = new ActionCommand(
+                _ => PluginFiles.Count > 0,
+                _ =>
+                {
+                    var selectedFiles = PluginFiles
+                        .Where(f => f.IsSelected)
+                        .Select(f => f.FilePath)
+                        .ToList();
+                    _closeAction(true, selectedFiles);
+                });
+
+            CancelCommand = new ActionCommand(
+                _ => true,
+                _ => _closeAction(false, []));
+
+            DeleteCommand = new ActionCommand(
+                parameter => parameter is IList list && list.Count > 0,
+                parameter =>
+                {
+                    if (parameter is not IList selectedItems) return;
+
+                    var pluginToDelete = selectedItems.OfType<SelectablePluginFile>().ToList();
+
+                    foreach (var plugin in pluginToDelete)
+                    {
+                        try
+                        {
+                            if (File.Exists(plugin.FilePath))
+                            {
+                                File.Delete(plugin.FilePath);
+                            }
+                            PluginFiles.Remove(plugin);
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show(string.Format(Texts.ErrorMessage, ex.Message));
+                        }
+                    }
+                     ((ActionCommand)InstallCommand).RaiseCanExecuteChanged();
+                });
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/PluginSelectionWindow.xaml
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/PluginSelectionWindow.xaml
@@ -1,0 +1,45 @@
+﻿<Window x:Class="YukkuriMovieMaker.Plugin.Community.Tool.PluginPortal.PluginSelectionWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:YukkuriMovieMaker.Plugin.Community.Tool.PluginPortal"
+        xmlns:c="clr-namespace:YukkuriMovieMaker.Controls;assembly=YukkuriMovieMaker.Controls"
+        mc:Ignorable="d"
+        Title="{x:Static local:Texts.PluginsToInstall}"
+        Height="300" Width="450"
+        d:DataContext="{d:DesignInstance Type=local:PluginSelectionViewModel}">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Button Grid.Row="0"
+                Content="{x:Static local:Texts.Delete}" 
+                Command="{Binding DeleteCommand}"
+                CommandParameter="{Binding ElementName=pluginDataGrid, Path=SelectedItems}"
+                HorizontalAlignment="Right"
+                Height="25" Width="100"/>
+
+        <DataGrid Grid.Row="1" 
+                  x:Name="pluginDataGrid"
+                  ItemsSource="{Binding PluginFiles}"
+                  SelectionChanged="PluginDataGrid_SelectionChanged"
+                  AutoGenerateColumns="False"
+                  CanUserAddRows="False"
+                  CanUserDeleteRows="False"
+                  Margin="0">
+            <DataGrid.Columns>
+                <DataGridCheckBoxColumn Header="{x:Static local:Texts.Install}" Binding="{Binding IsSelected}" Width="Auto" />
+                <DataGridTextColumn Header="{x:Static local:Texts.FileName}" Binding="{Binding FileName}" Width="*" IsReadOnly="True" />
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Height="25">
+            <Button Content="{x:Static local:Texts.Install}" Command="{Binding InstallCommand}" IsDefault="True" Width="100" />
+            <Button Content="{x:Static local:Texts.Cancel}" Command="{Binding CancelCommand}" IsCancel="True" Width="100" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/PluginSelectionWindow.xaml.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/PluginSelectionWindow.xaml.cs
@@ -1,0 +1,34 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using YukkuriMovieMaker.Commons;
+
+namespace YukkuriMovieMaker.Plugin.Community.Tool.PluginPortal
+{
+    /// <summary>
+    /// PluginSelectionWindow.xaml の相互作用ロジック
+    /// </summary>
+    public partial class PluginSelectionWindow : Window
+    {
+        public IEnumerable<string> SelectedFiles { get; private set; } = new List<string>();
+
+        public PluginSelectionWindow(IEnumerable<string> filePaths)
+        {
+            InitializeComponent();
+
+            DataContext = new PluginSelectionViewModel(filePaths, (result, selectedFiles) =>
+            {
+                this.SelectedFiles = selectedFiles;
+                this.DialogResult = result;
+                this.Close();
+            });
+        }
+
+        private void PluginDataGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (this.DataContext is PluginSelectionViewModel viewModel)
+            {
+                ((ActionCommand)viewModel.DeleteCommand).RaiseCanExecuteChanged();
+            }
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/SelectablePluginFile.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/SelectablePluginFile.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+using YukkuriMovieMaker.Commons;
+
+namespace YukkuriMovieMaker.Plugin.Community.Tool.PluginPortal
+{
+    internal class SelectablePluginFile(string filePath) : Bindable
+    {
+        private bool _isSelected = true;
+
+        public string FilePath { get; } = filePath;
+        public string FileName { get; } = Path.GetFileName(filePath);
+
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set => Set(ref _isSelected, value);
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.ar-sa.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.ar-sa.resx
@@ -83,7 +83,12 @@
 <data name="InstallAllMessage" xml:space="preserve"><value>تثبيت جميع الإضافات التي تم تنزيلها وعددها {0}.\nتحتاج إلى إغلاق YMM4 لبدء التثبيت.\n\nهل تريد المتابعة؟</value></data>
 <data name="InstallAllPlugins" xml:space="preserve"><value>تثبيت جميع الإضافات</value></data>
 <data name="CancelBulkInstallation" xml:space="preserve"><value>تم إلغاء التثبيت بالجملة.</value></data>
-<data name="InstallPluginsMessage" xml:space="preserve"><value>هل تريد تثبيت الإضافات التالية؟</value></data>
+<data name="NoPluginsSelected" xml:space="preserve"><value>لم يتم تحديد أي إضافات للتثبيت.</value></data>
+<data name="PluginsToInstall" xml:space="preserve"><value>الإضافات للتثبيت</value></data>
+<data name="Delete" xml:space="preserve"><value>حذف</value></data>
+<data name="Install" xml:space="preserve"><value>تثبيت</value></data>
+<data name="FileName" xml:space="preserve"><value>اسم الملف</value></data>
+<data name="Cancel" xml:space="preserve"><value>إلغاء</value></data>
 <data name="IsCleanYmmeFile" xml:space="preserve"><value>حذف ملف .ymme بعد التثبيت</value></data>
 <data name="YmmeFilePath" xml:space="preserve"><value>مسار ملف .ymme</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.csv
@@ -8,7 +8,7 @@ Description,,説明,Description,描述,描述,설명,Descripción,الوصف,Des
 IsEnabled,,配布終了,Discontinued,已停止分发,已停止發佈,배포 종료,Descontinuado,تم إيقاف التوزيع,Dihentikan,
 DownloadFromGitHub,,GitHubからダウンロード,Download from GitHub,从GitHub下载,從GitHub下載,GitHub에서 다운로드,Descargar desde GitHub,التنزيل من GitHub,Unduh dari GitHub,
 Search,,検索,Search,搜索,搜尋,검색,Cerrar,إغلاق,Tutup,
-InstallDownloaded,,ダウンロード済みをインストール,Install downloaded,安装已下载,安裝已下載,다운로드한 항목 설치,Instalar descargado,تثبيت الذي تم تنزيله,Pasang yang diunduh,
+InstallDownloaded,,ダウンロード済みをインストール,Install Downloaded,安装已下载,安裝已下載,다운로드한 항목 설치,Instalar descargado,تثبيت الذي تم تنزيله,Pasang yang Diunduh,
 
 InvalidGitHubURL,,無効なGitHub URLです。,Invalid GitHub URL,无效的GitHub URL,無效的GitHub URL,잘못된 GitHub URL,URL de GitHub no válido,رابط GitHub غير صالح,URL GitHub tidak valid,
 FetchingLatestRelease,,最新のリリースを取得中...,Fetching latest release...,正在获取最新版本...,正在取得最新版本...,최신 릴리스 가져오는 중...,Obteniendo la última versión...,جاري جلب الإصدار الأخير...,Mengambil rilis terbaru...,
@@ -24,7 +24,13 @@ NoDownloadablePlugins,,インストール可能なダウンロード済みプラ
 InstallAllMessage,,ダウンロード済みのプラグイン {0} 件をすべてインストールします。\nインストールを開始するにはゆっくりMovieMaker4を終了する必要があります。\n\n実行しますか？,Install all {0} downloaded plugins.\nYou need to close YMM4 to start the installation.\n\nDo you want to proceed?,安装所有 {0} 个下载的插件。\n您需要关闭 YMM4 以开始安装。\n\n要继续吗？,安裝所有 {0} 個下載的外掛程式。\n您需要關閉 YMM4 以開始安裝。\n\n要繼續嗎？,다운로드한 플러그인 {0}개를 모두 설치합니다.\n설치를 시작하려면 YMM4를 종료해야 합니다.\n\n실행하시겠습니까?,Instalar todos los {0} complementos descargados.\nNecesita cerrar YMM4 para iniciar la instalación.\n\n¿Desea continuar?,تثبيت جميع الإضافات التي تم تنزيلها وعددها {0}.\nتحتاج إلى إغلاق YMM4 لبدء التثبيت.\n\nهل تريد المتابعة؟,Pasang semua {0} plugin yang diunduh.\nAnda perlu menutup YMM4 untuk memulai instalasi.\n\nApakah Anda ingin melanjutkan?,
 InstallAllPlugins,,プラグイン一括インストール,Install All Plugins,批量安装插件,批量安裝外掛程式,플러그인 일괄 설치,Instalar todos los complementos,تثبيت جميع الإضافات,Pasang Semua Plugin,
 CancelBulkInstallation,,一括インストールはキャンセルされました。,Batch installation has been canceled.,批量安装已取消。,批量安裝已取消。,일괄 설치가 취소되었습니다.,La instalación por lotes ha sido cancelada.,تم إلغاء التثبيت بالجملة.,Instalasi batch telah dibatalkan.,
-InstallPluginsMessage,,以下のプラグインをインストールしますか？,Do you want to install the following plugins?,是否要安装以下插件？,是否要安裝以下外掛程式？,다음 플러그인을 설치하시겠습니까?,¿Desea instalar los siguientes complementos?,هل تريد تثبيت الإضافات التالية؟,Apakah Anda ingin menginstal plugin berikut?,
+NoPluginsSelected,,インストールするプラグインが選択されませんでした。,No plugins selected for installation.,未选择要安装的插件。,未選擇要安裝的外掛程式。,설치할 플러그인이 선택되지 않았습니다.,No se seleccionaron complementos para la instalación.,لم يتم تحديد أي إضافات للتثبيت.,Tidak ada plugin yang dipilih untuk diinstal.,
+
+PluginsToInstall,,インストールするプラグイン,Plugins to Install,要安装的插件,要安裝的外掛程式,설치할 플러그인,Complementos para instalar,الإضافات للتثبيت,Plugin untuk Dipasang,
+Delete,,削除,Delete,删除,刪除,삭제,Eliminar,حذف,Hapus,
+Install,,インストール,Install,安装,安裝,설치,Instalar,تثبيت,Pasang,
+FileName,,ファイル名,File Name,文件名,檔案名稱,파일 이름,Nombre de archivo,اسم الملف,Nama File,
+Cancel,,キャンセル,Cancel,取消,取消,취소,Cancelar,إلغاء,Batalkan,
 
 IsCleanYmmeFile,,インストール後に .ymme を削除する,Delete .ymme file after installation,.ymme 文件安装后删除,.ymme 檔案安裝後刪除,설치 후 .ymme 파일 삭제,Eliminar archivo .ymme después de la instalación,حذف ملف .ymme بعد التثبيت,Hapus file .ymme setelah instalasi,
 YmmeFilePath,,.ymme の保存先,.ymme file path,.ymme 文件路径,.ymme 檔案路徑,.ymme 파일 경로,Ruta del archivo .ymme,مسار ملف .ymme,Path file .ymme,

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.en-us.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.en-us.resx
@@ -68,7 +68,7 @@
 <data name="IsEnabled" xml:space="preserve"><value>Discontinued</value></data>
 <data name="DownloadFromGitHub" xml:space="preserve"><value>Download from GitHub</value></data>
 <data name="Search" xml:space="preserve"><value>Search</value></data>
-<data name="InstallDownloaded" xml:space="preserve"><value>Install downloaded</value></data>
+<data name="InstallDownloaded" xml:space="preserve"><value>Install Downloaded</value></data>
 <data name="InvalidGitHubURL" xml:space="preserve"><value>Invalid GitHub URL</value></data>
 <data name="FetchingLatestRelease" xml:space="preserve"><value>Fetching latest release...</value></data>
 <data name="FailedToParseReleaseInfo" xml:space="preserve"><value>Failed to parse release info.</value></data>
@@ -83,7 +83,12 @@
 <data name="InstallAllMessage" xml:space="preserve"><value>Install all {0} downloaded plugins.\nYou need to close YMM4 to start the installation.\n\nDo you want to proceed?</value></data>
 <data name="InstallAllPlugins" xml:space="preserve"><value>Install All Plugins</value></data>
 <data name="CancelBulkInstallation" xml:space="preserve"><value>Batch installation has been canceled.</value></data>
-<data name="InstallPluginsMessage" xml:space="preserve"><value>Do you want to install the following plugins?</value></data>
+<data name="NoPluginsSelected" xml:space="preserve"><value>No plugins selected for installation.</value></data>
+<data name="PluginsToInstall" xml:space="preserve"><value>Plugins to Install</value></data>
+<data name="Delete" xml:space="preserve"><value>Delete</value></data>
+<data name="Install" xml:space="preserve"><value>Install</value></data>
+<data name="FileName" xml:space="preserve"><value>File Name</value></data>
+<data name="Cancel" xml:space="preserve"><value>Cancel</value></data>
 <data name="IsCleanYmmeFile" xml:space="preserve"><value>Delete .ymme file after installation</value></data>
 <data name="YmmeFilePath" xml:space="preserve"><value>.ymme file path</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.es-es.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.es-es.resx
@@ -83,7 +83,12 @@
 <data name="InstallAllMessage" xml:space="preserve"><value>Instalar todos los {0} complementos descargados.\nNecesita cerrar YMM4 para iniciar la instalación.\n\n¿Desea continuar?</value></data>
 <data name="InstallAllPlugins" xml:space="preserve"><value>Instalar todos los complementos</value></data>
 <data name="CancelBulkInstallation" xml:space="preserve"><value>La instalación por lotes ha sido cancelada.</value></data>
-<data name="InstallPluginsMessage" xml:space="preserve"><value>¿Desea instalar los siguientes complementos?</value></data>
+<data name="NoPluginsSelected" xml:space="preserve"><value>No se seleccionaron complementos para la instalación.</value></data>
+<data name="PluginsToInstall" xml:space="preserve"><value>Complementos para instalar</value></data>
+<data name="Delete" xml:space="preserve"><value>Eliminar</value></data>
+<data name="Install" xml:space="preserve"><value>Instalar</value></data>
+<data name="FileName" xml:space="preserve"><value>Nombre de archivo</value></data>
+<data name="Cancel" xml:space="preserve"><value>Cancelar</value></data>
 <data name="IsCleanYmmeFile" xml:space="preserve"><value>Eliminar archivo .ymme después de la instalación</value></data>
 <data name="YmmeFilePath" xml:space="preserve"><value>Ruta del archivo .ymme</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.id-id.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.id-id.resx
@@ -68,7 +68,7 @@
 <data name="IsEnabled" xml:space="preserve"><value>Dihentikan</value></data>
 <data name="DownloadFromGitHub" xml:space="preserve"><value>Unduh dari GitHub</value></data>
 <data name="Search" xml:space="preserve"><value>Tutup</value></data>
-<data name="InstallDownloaded" xml:space="preserve"><value>Pasang yang diunduh</value></data>
+<data name="InstallDownloaded" xml:space="preserve"><value>Pasang yang Diunduh</value></data>
 <data name="InvalidGitHubURL" xml:space="preserve"><value>URL GitHub tidak valid</value></data>
 <data name="FetchingLatestRelease" xml:space="preserve"><value>Mengambil rilis terbaru...</value></data>
 <data name="FailedToParseReleaseInfo" xml:space="preserve"><value>Gagal mengurai info rilis.</value></data>
@@ -83,7 +83,12 @@
 <data name="InstallAllMessage" xml:space="preserve"><value>Pasang semua {0} plugin yang diunduh.\nAnda perlu menutup YMM4 untuk memulai instalasi.\n\nApakah Anda ingin melanjutkan?</value></data>
 <data name="InstallAllPlugins" xml:space="preserve"><value>Pasang Semua Plugin</value></data>
 <data name="CancelBulkInstallation" xml:space="preserve"><value>Instalasi batch telah dibatalkan.</value></data>
-<data name="InstallPluginsMessage" xml:space="preserve"><value>Apakah Anda ingin menginstal plugin berikut?</value></data>
+<data name="NoPluginsSelected" xml:space="preserve"><value>Tidak ada plugin yang dipilih untuk diinstal.</value></data>
+<data name="PluginsToInstall" xml:space="preserve"><value>Plugin untuk Dipasang</value></data>
+<data name="Delete" xml:space="preserve"><value>Hapus</value></data>
+<data name="Install" xml:space="preserve"><value>Pasang</value></data>
+<data name="FileName" xml:space="preserve"><value>Nama File</value></data>
+<data name="Cancel" xml:space="preserve"><value>Batalkan</value></data>
 <data name="IsCleanYmmeFile" xml:space="preserve"><value>Hapus file .ymme setelah instalasi</value></data>
 <data name="YmmeFilePath" xml:space="preserve"><value>Path file .ymme</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.ko-kr.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.ko-kr.resx
@@ -83,7 +83,12 @@
 <data name="InstallAllMessage" xml:space="preserve"><value>다운로드한 플러그인 {0}개를 모두 설치합니다.\n설치를 시작하려면 YMM4를 종료해야 합니다.\n\n실행하시겠습니까?</value></data>
 <data name="InstallAllPlugins" xml:space="preserve"><value>플러그인 일괄 설치</value></data>
 <data name="CancelBulkInstallation" xml:space="preserve"><value>일괄 설치가 취소되었습니다.</value></data>
-<data name="InstallPluginsMessage" xml:space="preserve"><value>다음 플러그인을 설치하시겠습니까?</value></data>
+<data name="NoPluginsSelected" xml:space="preserve"><value>설치할 플러그인이 선택되지 않았습니다.</value></data>
+<data name="PluginsToInstall" xml:space="preserve"><value>설치할 플러그인</value></data>
+<data name="Delete" xml:space="preserve"><value>삭제</value></data>
+<data name="Install" xml:space="preserve"><value>설치</value></data>
+<data name="FileName" xml:space="preserve"><value>파일 이름</value></data>
+<data name="Cancel" xml:space="preserve"><value>취소</value></data>
 <data name="IsCleanYmmeFile" xml:space="preserve"><value>설치 후 .ymme 파일 삭제</value></data>
 <data name="YmmeFilePath" xml:space="preserve"><value>.ymme 파일 경로</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.resx
@@ -83,7 +83,12 @@
 <data name="InstallAllMessage" xml:space="preserve"><value>ダウンロード済みのプラグイン {0} 件をすべてインストールします。\nインストールを開始するにはゆっくりMovieMaker4を終了する必要があります。\n\n実行しますか？</value></data>
 <data name="InstallAllPlugins" xml:space="preserve"><value>プラグイン一括インストール</value></data>
 <data name="CancelBulkInstallation" xml:space="preserve"><value>一括インストールはキャンセルされました。</value></data>
-<data name="InstallPluginsMessage" xml:space="preserve"><value>以下のプラグインをインストールしますか？</value></data>
+<data name="NoPluginsSelected" xml:space="preserve"><value>インストールするプラグインが選択されませんでした。</value></data>
+<data name="PluginsToInstall" xml:space="preserve"><value>インストールするプラグイン</value></data>
+<data name="Delete" xml:space="preserve"><value>削除</value></data>
+<data name="Install" xml:space="preserve"><value>インストール</value></data>
+<data name="FileName" xml:space="preserve"><value>ファイル名</value></data>
+<data name="Cancel" xml:space="preserve"><value>キャンセル</value></data>
 <data name="IsCleanYmmeFile" xml:space="preserve"><value>インストール後に .ymme を削除する</value></data>
 <data name="YmmeFilePath" xml:space="preserve"><value>.ymme の保存先</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.zh-cn.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.zh-cn.resx
@@ -83,7 +83,12 @@
 <data name="InstallAllMessage" xml:space="preserve"><value>安装所有 {0} 个下载的插件。\n您需要关闭 YMM4 以开始安装。\n\n要继续吗？</value></data>
 <data name="InstallAllPlugins" xml:space="preserve"><value>批量安装插件</value></data>
 <data name="CancelBulkInstallation" xml:space="preserve"><value>批量安装已取消。</value></data>
-<data name="InstallPluginsMessage" xml:space="preserve"><value>是否要安装以下插件？</value></data>
+<data name="NoPluginsSelected" xml:space="preserve"><value>未选择要安装的插件。</value></data>
+<data name="PluginsToInstall" xml:space="preserve"><value>要安装的插件</value></data>
+<data name="Delete" xml:space="preserve"><value>删除</value></data>
+<data name="Install" xml:space="preserve"><value>安装</value></data>
+<data name="FileName" xml:space="preserve"><value>文件名</value></data>
+<data name="Cancel" xml:space="preserve"><value>取消</value></data>
 <data name="IsCleanYmmeFile" xml:space="preserve"><value>.ymme 文件安装后删除</value></data>
 <data name="YmmeFilePath" xml:space="preserve"><value>.ymme 文件路径</value></data>
 </root>

--- a/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.zh-tw.resx
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/PluginPortal/Texts.zh-tw.resx
@@ -83,7 +83,12 @@
 <data name="InstallAllMessage" xml:space="preserve"><value>安裝所有 {0} 個下載的外掛程式。\n您需要關閉 YMM4 以開始安裝。\n\n要繼續嗎？</value></data>
 <data name="InstallAllPlugins" xml:space="preserve"><value>批量安裝外掛程式</value></data>
 <data name="CancelBulkInstallation" xml:space="preserve"><value>批量安裝已取消。</value></data>
-<data name="InstallPluginsMessage" xml:space="preserve"><value>是否要安裝以下外掛程式？</value></data>
+<data name="NoPluginsSelected" xml:space="preserve"><value>未選擇要安裝的外掛程式。</value></data>
+<data name="PluginsToInstall" xml:space="preserve"><value>要安裝的外掛程式</value></data>
+<data name="Delete" xml:space="preserve"><value>刪除</value></data>
+<data name="Install" xml:space="preserve"><value>安裝</value></data>
+<data name="FileName" xml:space="preserve"><value>檔案名稱</value></data>
+<data name="Cancel" xml:space="preserve"><value>取消</value></data>
 <data name="IsCleanYmmeFile" xml:space="preserve"><value>.ymme 檔案安裝後刪除</value></data>
 <data name="YmmeFilePath" xml:space="preserve"><value>.ymme 檔案路徑</value></data>
 </root>


### PR DESCRIPTION
## 変更
- 「ダウンロード済みをインストール」をクリックすると、以下のようにインストールするプラグインを選択できるように変更。
<img width="1163" alt="スクリーンショット 2025-09-02 164415" src="https://github.com/user-attachments/assets/e0ec6410-6763-49ee-81dc-1813de57205a" />

- GridSplitterを追加して範囲を変えられるように。

## 報告
インストーラーの--dirフラグがディレクトリ内のymmeを1つしか実行してくれないみたいです。