### PR TITLE
図形「数値」で一部フォントが適用されない問題を修正

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Shape/NumberText/NumberTextSource.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Shape/NumberText/NumberTextSource.cs
@@ -66,9 +66,10 @@ internal sealed class NumberTextSource(IGraphicsDevicesAndContext devices, Numbe
         using var formatFactory = DWriteCreateFactory<IDWriteFactory>();
         using var textFormat = 
             formatFactory.CreateTextFormat(
-                font, 
+                f.CanonicalFontName, 
                 isBold && f.CanonicalFontWeight < Settings.FontWeight.Bold ? FontWeight.Bold : (FontWeight)f.CanonicalFontWeight,
                 isItalic ? FontStyle.Italic : (FontStyle)f.CanonicalFontStyle, 
+                (FontStretch)f.CanonicalFontStretch,
                 fontSize);
 
         textFormat.WordWrapping = WordWrapping.NoWrap;


### PR DESCRIPTION
細かくて申し訳ないのですが、気付いてしまったのでPR送らせていただきます。

不具合内容：
図形「数値」でごく一部のフォント（『やさしさゴシックボールドV2』や『機械彫刻用標準書体 M』で確認）が適用されず、フォールバックされたフォントで表示される。

原因の推測：
`[FontComboBox]`から取得した文字列をそのまま渡すと`font.CanonicalFontName`ではなく`font.CanDisplayFontName`相当なので、その2つにズレがあるフォントが適用されないためと思われます。

実装について：
エフェクト「シャッフルテキスト」だと問題なく適用できたので、その以下の実装を参考に直しました。
FontStretchの指定の有無で問題が発生するかは未確認ですが、どちらかと言えばあった方が良さそうなのでその引数も付け付加しました。
https://github.com/manju-summoner/YukkuriMovieMaker.Plugin.Community/blob/4a37b915f5bbf3b74000263bc15d49a5c1b00401/YukkuriMovieMaker.Plugin.Community/Effect/Video/ShuffleText/ShuffleTextEffectProcessor.cs#L56