### PR TITLE
エクスプローラーのバグ修正

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Tool/Explorer/ExplorerViewModel.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Explorer/ExplorerViewModel.cs
@@ -561,7 +561,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Explorer
                                 else if (File.Exists(path))
                                     archive.CreateEntryFromFile(path, Path.GetFileName(path));
                             }
-                            
+
                             Application.Current.Dispatcher.Invoke(() => RequestRefresh());
                         }
                         catch (Exception e)
@@ -839,12 +839,10 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Explorer
             if (p is ExplorerSidebarDirectoryViewModel sidebarVm)
             {
                 if (sidebarVm.IsExpanded)
-                {
                     CollapseSidebarItem(sidebarVm);
-                    sidebarVm.ResetExpandedState();
-                }
+
                 await ExpandSidebarItemAsync(sidebarVm);
-                sidebarVm.IsExpanded = true;
+                sidebarVm.MarkExpanded();
 
                 var newItem = SidebarItems.FirstOrDefault(x => string.Equals(x.Path, path, StringComparison.OrdinalIgnoreCase));
                 if (newItem != null)
@@ -1478,8 +1476,6 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Explorer
             }
         }
 
-
-
         private void Watcher_Callback(object sender, FileSystemEventArgs e)
         {
             if (e.ChangeType is WatcherChangeTypes.Deleted)
@@ -1542,7 +1538,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Explorer
 
             var orderedDirs = dirs.OrderBy(d => d.dir.Name).ToList();
             int insertIndex = SidebarItems.IndexOf(parent) + 1;
-            
+
             foreach (var item in orderedDirs)
             {
                 bool found = false;
@@ -1581,7 +1577,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Explorer
                     insertIndex++;
                 }
             }
-            
+
             parent.SetHasDummyChild(orderedDirs.Count > 0);
         }
 

--- a/YukkuriMovieMaker.Plugin.Community/Tool/Explorer/RenameTextBoxBehavior.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Explorer/RenameTextBoxBehavior.cs
@@ -19,6 +19,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Explorer
         protected override void OnAttached()
         {
             base.OnAttached();
+            AssociatedObject.Loaded += AssociatedObject_Loaded;
             AssociatedObject.IsVisibleChanged += AssociatedObject_IsVisibleChanged;
             AssociatedObject.LostFocus += AssociatedObject_LostFocus;
             AssociatedObject.PreviewKeyDown += AssociatedObject_PreviewKeyDown;
@@ -28,42 +29,53 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Explorer
         protected override void OnDetaching()
         {
             base.OnDetaching();
+            AssociatedObject.Loaded -= AssociatedObject_Loaded;
             AssociatedObject.IsVisibleChanged -= AssociatedObject_IsVisibleChanged;
             AssociatedObject.LostFocus -= AssociatedObject_LostFocus;
             AssociatedObject.PreviewKeyDown -= AssociatedObject_PreviewKeyDown;
             AssociatedObject.PreviewMouseDown -= AssociatedObject_PreviewMouseDown;
         }
 
+        private void AssociatedObject_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (AssociatedObject.IsVisible)
+                TryActivateRenaming();
+        }
+
         private void AssociatedObject_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            if ((bool)e.NewValue && AssociatedObject.DataContext is IExplorerSelectableItem item && item.IsRenaming)
+            if ((bool)e.NewValue)
+                TryActivateRenaming();
+        }
+
+        void TryActivateRenaming()
+        {
+            if (AssociatedObject.DataContext is not IExplorerSelectableItem item || !item.IsRenaming)
+                return;
+
+            AssociatedObject.Dispatcher.InvokeAsync(() =>
             {
-                AssociatedObject.Dispatcher.InvokeAsync(() =>
-                {
-                    AssociatedObject.Focus();
+                if (!item.IsRenaming || AssociatedObject.DataContext != item)
+                    return;
 
-                    var text = AssociatedObject.Text;
-                    var extIndex = text.LastIndexOf('.');
+                AssociatedObject.Focus();
 
-                    var selectsNameOnly = item is IExplorerItemViewModel vm && vm.SelectsNameOnlyOnRename;
-                    if (extIndex > 0 && selectsNameOnly)
-                    {
-                        AssociatedObject.Select(0, extIndex);
-                    }
-                    else
-                    {
-                        AssociatedObject.SelectAll();
-                    }
-                }, System.Windows.Threading.DispatcherPriority.Input);
-            }
+                var text = AssociatedObject.Text;
+                var extIndex = text.LastIndexOf('.');
+                var selectsNameOnly = item is IExplorerItemViewModel vm && vm.SelectsNameOnlyOnRename;
+
+                if (extIndex > 0 && selectsNameOnly)
+                    AssociatedObject.Select(0, extIndex);
+                else
+                    AssociatedObject.SelectAll();
+
+            }, System.Windows.Threading.DispatcherPriority.Loaded);
         }
 
         private void AssociatedObject_LostFocus(object sender, RoutedEventArgs e)
         {
             if (AssociatedObject.DataContext is IExplorerSelectableItem item && item.IsRenaming)
-            {
                 CommitRename(item);
-            }
         }
 
         private void AssociatedObject_PreviewKeyDown(object sender, KeyEventArgs e)
@@ -71,17 +83,13 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Explorer
             if (e.Key == Key.Enter)
             {
                 if (AssociatedObject.DataContext is IExplorerSelectableItem item)
-                {
                     CommitRename(item);
-                }
                 e.Handled = true;
             }
             else if (e.Key == Key.Escape)
             {
                 if (AssociatedObject.DataContext is IExplorerSelectableItem item)
-                {
                     item.IsRenaming = false;
-                }
                 e.Handled = true;
             }
         }
@@ -99,13 +107,9 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Explorer
         {
             var command = CommitRenameCommand;
             if (command?.CanExecute(item) == true)
-            {
                 command.Execute(item);
-            }
             else
-            {
                 item.IsRenaming = false;
-            }
         }
     }
 }


### PR DESCRIPTION
## 修正バグ

### 1. 新規フォルダ作成時にリネームテキストが選択されない

メインリストからの新規フォルダ作成では、IsRenaming=trueを設定したタイミングでListBoxのアイテムコンテナがまだ生成されていない場合がありました。ScrollSelectedItemIntoViewBehaviorがDispatcherPriority.Loadedでスクロール・コンテナ生成を行うため、その後にTextBoxが初めてロードされますが、既存のIsVisibleChangedハンドラだけでは捕捉できないケースがありました。
RenameTextBoxBehaviorにLoadedイベントハンドラを追加し、IsVisibleChangedと共通のTryActivateRenaming()を呼ぶことで、いずれのタイミングでも確実にフォーカス・選択が行われるようにしました。ディスパッチ優先度もInputからLoadedに引き上げ、レイアウト完了を保証します。

### 2. サイドバーで連続してフォルダを作成するとフォルダ名が増殖する

AfterFolderCreatedAsyncでsidebarVm.IsExpanded=trueを使っていたため、ExpandRequestedイベントが発火しExpandSidebarItemAsyncが二重に実行されていました。IsExpandingフラグはfinallyでリセット済みのため二重実行を防げていませんでした。
MarkExpanded()を使うよう修正しました。