### PR TITLE
出力を分岐、合成、切替でAffineTransform2D(Cached)によるブランチポイントの最適化

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/OutputBranch/OutputBranchEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/OutputBranch/OutputBranchEffectProcessor.cs
@@ -6,15 +6,10 @@ using YukkuriMovieMaker.Player.Video.Effects;
 
 namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.OutputBranch
 {
-    internal class OutputBranchEffectProcessor : VideoEffectProcessorBase
+    internal class OutputBranchEffectProcessor(IGraphicsDevicesAndContext devices) : VideoEffectProcessorBase(devices)
     {
         private AffineTransform2D? transformEffect;
         private ID2D1Image? transformOutput;
-
-        public OutputBranchEffectProcessor(IGraphicsDevicesAndContext devices) : base(devices)
-        {
-
-        }
 
         public override DrawDescription Update(EffectDescription effectDescription)
         {

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/OutputBranch/OutputBranchEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/OutputBranch/OutputBranchEffectProcessor.cs
@@ -1,31 +1,59 @@
 using Vortice.Direct2D1;
+using Vortice.Direct2D1.Effects;
 using YukkuriMovieMaker.Commons;
 using YukkuriMovieMaker.Player.Video;
 using YukkuriMovieMaker.Player.Video.Effects;
 
 namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.OutputBranch
 {
-    internal class OutputBranchEffectProcessor(IGraphicsDevicesAndContext devices) : VideoEffectProcessorBase(devices)
+    internal class OutputBranchEffectProcessor : VideoEffectProcessorBase
     {
+        private AffineTransform2D? transformEffect;
+
+        public OutputBranchEffectProcessor(IGraphicsDevicesAndContext devices) : base(devices)
+        {
+
+        }
+
         public override DrawDescription Update(EffectDescription effectDescription)
         {
             var desc = effectDescription.DrawDescription;
-            if (input is null)
+            if (input is null || transformEffect is null)
                 return desc;
 
             var next = desc.GetCustomValue<int>("OutputBranch.NextBranchIndex");
             if (next <= 0)
                 next = 1;
 
-            desc = desc.SetCustomValue<ID2D1Image>(input, $"OutputBranch.Branch{next}");
+            desc = desc.SetCustomValue<ID2D1Image>(transformEffect.Output, $"OutputBranch.Branch{next}");
             desc = desc.SetCustomValue<int>(next + 1, "OutputBranch.NextBranchIndex");
             return desc;
         }
 
-        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices) => null;
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            transformEffect = new AffineTransform2D(devices.DeviceContext)
+            {
+                Cached = true
+            };
+            return transformEffect.Output;
+        }
 
-        protected override void setInput(ID2D1Image? input) { }
+        protected override void setInput(ID2D1Image? input)
+        {
+            if (transformEffect != null)
+            {
+                transformEffect.SetInput(0, input, true);
+            }
+        }
 
-        protected override void ClearEffectChain() { }
+        protected override void ClearEffectChain()
+        {
+            if (transformEffect != null)
+            {
+                transformEffect.Dispose();
+                transformEffect = null;
+            }
+        }
     }
 }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/OutputBranch/OutputBranchEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/OutputBranch/OutputBranchEffectProcessor.cs
@@ -9,6 +9,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.OutputBranch
     internal class OutputBranchEffectProcessor : VideoEffectProcessorBase
     {
         private AffineTransform2D? transformEffect;
+        private ID2D1Image? transformOutput;
 
         public OutputBranchEffectProcessor(IGraphicsDevicesAndContext devices) : base(devices)
         {
@@ -18,14 +19,14 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.OutputBranch
         public override DrawDescription Update(EffectDescription effectDescription)
         {
             var desc = effectDescription.DrawDescription;
-            if (input is null || transformEffect is null)
+            if (input is null || transformOutput is null)
                 return desc;
 
             var next = desc.GetCustomValue<int>("OutputBranch.NextBranchIndex");
             if (next <= 0)
                 next = 1;
 
-            desc = desc.SetCustomValue<ID2D1Image>(transformEffect.Output, $"OutputBranch.Branch{next}");
+            desc = desc.SetCustomValue<ID2D1Image>(transformOutput, $"OutputBranch.Branch{next}");
             desc = desc.SetCustomValue<int>(next + 1, "OutputBranch.NextBranchIndex");
             return desc;
         }
@@ -36,24 +37,21 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.OutputBranch
             {
                 Cached = true
             };
-            return transformEffect.Output;
+            disposer.Collect(transformEffect);
+
+            transformOutput = transformEffect.Output;
+            disposer.Collect(transformOutput);
+            return transformOutput;
         }
 
         protected override void setInput(ID2D1Image? input)
         {
-            if (transformEffect != null)
-            {
-                transformEffect.SetInput(0, input, true);
-            }
+            transformEffect?.SetInput(0, input, true);
         }
 
         protected override void ClearEffectChain()
         {
-            if (transformEffect != null)
-            {
-                transformEffect.Dispose();
-                transformEffect = null;
-            }
+            transformEffect?.SetInput(0, null, true);
         }
     }
 }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/OutputComposite/OutputCompositeEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/OutputComposite/OutputCompositeEffectProcessor.cs
@@ -25,7 +25,10 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.OutputComposite
 
         protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
         {
-            sink = new D2DEffects.AffineTransform2D(devices.DeviceContext);
+            sink = new D2DEffects.AffineTransform2D(devices.DeviceContext)
+            {
+                Cached = true
+            };
             disposer.Collect(sink);
 
             compositeEffect = new D2DEffects.Composite(devices.DeviceContext) { InputCount = 2 };

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/OutputSwitch/OutputSwitchEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/OutputSwitch/OutputSwitchEffectProcessor.cs
@@ -19,7 +19,10 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.OutputSwitch
 
         protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
         {
-            sink = new D2DEffects.AffineTransform2D(devices.DeviceContext);
+            sink = new D2DEffects.AffineTransform2D(devices.DeviceContext)
+            {
+                Cached = true
+            };
             disposer.Collect(sink);
 
             var output = sink.Output;


### PR DESCRIPTION
OutputBranchエフェクトにおいて、分岐先へのID2D1Image受け渡しをAffineTransform2D経由に変更しました。

OutputBranchは入力を複数ブランチへ分岐させる用途であるため、ブランチ数が増えるほど上流の描画コストが線形に倍増するという問題がありました。

ブランチポイント分のVRAMを常時確保するコストが発生しますが、ブランチ数に応じた計算量の線形増加を防ぐための必要なコストと判断しています。