### PR TITLE
エクスプローラーでデバッグ時にOperationCanceledExceptionが未処理例外として表示される問題を修正

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Tool/Explorer/ExplorerViewModel.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Explorer/ExplorerViewModel.cs
@@ -1221,13 +1221,14 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Explorer
                 AttributesToSkip = FileAttributes.Hidden | FileAttributes.System,
             };
 
-            var (dirsInfo, filesInfo) = await Task.Run(() =>
+            var result = await Task.Run(() =>
             {
                 var di = new DirectoryInfo(currentLocation);
                 var d = new List<(DirectoryInfo dir, bool hasChild)>();
                 foreach (var dir in di.EnumerateDirectories("*", options))
                 {
-                    token.ThrowIfCancellationRequested();
+                    if (token.IsCancellationRequested)
+                        return null;
                     bool hasChild = false;
                     try { hasChild = dir.EnumerateDirectories("*", options).Any(); } catch { }
                     d.Add((dir, hasChild));
@@ -1236,15 +1237,19 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Explorer
                 var f = new List<FileInfo>();
                 foreach (var file in di.EnumerateFiles("*", options))
                 {
-                    token.ThrowIfCancellationRequested();
+                    if (token.IsCancellationRequested)
+                        return null;
                     f.Add(file);
                 }
-                return (d, f);
-            }, token);
+                return ((List<(DirectoryInfo dir, bool hasChild)> dirs, List<FileInfo> files)?)(d, f);
+            });
 
-            token.ThrowIfCancellationRequested();
+            if (result is null)
+                return;
 
             if (Location != currentLocation) return;
+
+            var (dirsInfo, filesInfo) = result.Value;
 
             var oldItemsMap = Items.ToDictionary(x => x.Path, StringComparer.OrdinalIgnoreCase);
             var newItemsList = new List<IExplorerItemViewModel>(dirsInfo.Count + filesInfo.Count);

--- a/YukkuriMovieMaker.Plugin.Community/Tool/Explorer/ExplorerViewModel.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Explorer/ExplorerViewModel.cs
@@ -1244,7 +1244,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Explorer
                 return ((List<(DirectoryInfo dir, bool hasChild)> dirs, List<FileInfo> files)?)(d, f);
             });
 
-            if (result is null)
+            if (result is null || token.IsCancellationRequested)
                 return;
 
             if (Location != currentLocation) return;


### PR DESCRIPTION
デバッグ実行時にVisual StudioがOperationCanceledExceptionを未処理例外として停止する問題を修正しました。

挙動へ影響はありません。