### PR TITLE
メモ帳でICSharpCode.AvalonEditの直接参照に変更

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
+++ b/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
@@ -46,9 +46,6 @@
 	  <Reference Include="System.Drawing.Common">
 		  <HintPath>$(YMM4DirPath)System.Drawing.Common.dll</HintPath>
 	  </Reference>
-	  <Reference Include="Vortice.Mathematics">
-		  <HintPath>$(YMM4DirPath)Vortice.Mathematics.dll</HintPath>
-	  </Reference>
 	  <Reference Include="ICSharpCode.AvalonEdit">
 		  <HintPath>$(YMM4DirPath)ICSharpCode.AvalonEdit.dll</HintPath>
 	  </Reference>

--- a/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
+++ b/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
@@ -49,6 +49,9 @@
 	  <Reference Include="Vortice.Mathematics">
 		  <HintPath>$(YMM4DirPath)Vortice.Mathematics.dll</HintPath>
 	  </Reference>
+	  <Reference Include="ICSharpCode.AvalonEdit">
+		  <HintPath>$(YMM4DirPath)ICSharpCode.AvalonEdit.dll</HintPath>
+	  </Reference>
   </ItemGroup>
 
   <ItemGroup>
@@ -70,7 +73,6 @@
 	<PackageReference Include="System.Management" Version="10.0.7" />
 	<PackageReference Include="ComputeSharp" Version="3.2.0" />
 	<PackageReference Include="MeltySynth" Version="2.4.1" />
-	<PackageReference Include="AvalonEdit" Version="6.3.1.120" />
   </ItemGroup>
 
   <!--ビルド後、YMM4フォルダに関連ファイルをコピーする-->


### PR DESCRIPTION
## PRの種類
<!-- 該当するものに [x] を付けてください -->
- [ ] 新機能の追加 → **`develop` ブランチ宛**にお願いします
- [ ] リリース済み機能のバグ修正 → **`master` ブランチ宛**にお願いします

## 概要
<!-- 変更内容を簡単に記載してください -->

YMM4内にすでにICSharpCode.AvalonEditのライブラリファイルが配置済みであったため、新規にNuGetパッケージを追加する必要がありませんでした。
バージョン管理の混乱を避け、既存のDLLをそのまま利用する形に統一しました。
機能面・動作面での変更はありません。
