### PR TITLE
映像エフェクト「余白除去」を追加

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/Texts.cs
@@ -1,0 +1,9 @@
+using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/Texts.csv
@@ -1,0 +1,7 @@
+Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+TrimMarginEffectName,,余白除去,Trim Margin,裁剪空白,裁剪空白,여백 제거,Recortar Margen,إزالة الهامش,Pangkas Margin
+TrimMarginCenterName,,中央寄せ,Center,居中,居中,가운데 정렬,Centrar,توسيط,Pusatkan
+TrimMarginCenterDesc,,余白を除去した後に映像を中央に配置します。,Centers the image after trimming the transparent margin.,裁剪透明边距后将图像居中。,裁剪透明邊距後將圖像居中。,투명 여백 제거 후 이미지를 가운데에 배치합니다.,Centra la imagen tras recortar el margen transparente.,يُرتّب الصورة في المنتصف بعد قصّ الهامش الشفاف.,Menempatkan gambar di tengah setelah memangkas margin transparan.
+TagTrimMargin,,余白除去,trim margin,裁剪空白,裁剪空白,여백 제거,recortar margen,إزالة الهامش,pangkas margin
+TagCrop,,クロップ,crop,裁剪,裁剪,크롭,recorte,قص,pangkas
+TagTransparent,,透明,transparent,透明,透明,투명,transparente,شفاف,transparan

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffect.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
+{
+    [VideoEffect(nameof(Texts.TrimMarginEffectName), [VideoEffectCategories.Filtering], [nameof(Texts.TagTrimMargin), nameof(Texts.TagCrop), nameof(Texts.TagTransparent)], IsAviUtlSupported = false, ResourceType = typeof(Texts))]
+    public sealed class TrimMarginEffect : VideoEffectBase
+    {
+        public override string Label => Texts.TrimMarginEffectName;
+
+        [Display(GroupName = nameof(Texts.TrimMarginEffectName), Name = nameof(Texts.TrimMarginCenterName), Description = nameof(Texts.TrimMarginCenterDesc), Order = 0, ResourceType = typeof(Texts))]
+        [ToggleSlider]
+        public bool Center
+        {
+            get => _center;
+            set => Set(ref _center, value);
+        }
+        private bool _center = true;
+
+        public override IEnumerable<string> CreateExoVideoFilters(int keyFrameIndex, ExoOutputDescription exoOutputDescription) => [];
+
+        public override IVideoEffectProcessor CreateVideoEffect(IGraphicsDevicesAndContext devices)
+            => new TrimMarginEffectProcessor(devices, this);
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [];
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Numerics;
+using Vortice.Direct2D1;
+using Vortice.Direct2D1.Effects;
+using Vortice.DCommon;
+using Vortice.Mathematics;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Player.Video.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
+{
+    internal sealed class TrimMarginEffectProcessor : VideoEffectProcessorBase
+    {
+        readonly TrimMarginEffect item;
+        readonly ID2D1DeviceContext isolatedContext;
+
+        Crop? cropEffect;
+        AffineTransform2D? translateEffect;
+        ID2D1Image? currentInput;
+
+        public TrimMarginEffectProcessor(IGraphicsDevicesAndContext devices, TrimMarginEffect item) : base(devices)
+        {
+            this.item = item;
+            isolatedContext = devices.DeviceContext.Device.CreateDeviceContext(DeviceContextOptions.None);
+            disposer.Collect(isolatedContext);
+        }
+
+        public override DrawDescription Update(EffectDescription effectDescription)
+        {
+            if (IsPassThroughEffect || cropEffect is null || translateEffect is null || currentInput is null)
+                return effectDescription.DrawDescription;
+
+            var trimRect = ComputeTrimRect(isolatedContext, currentInput);
+            if (!trimRect.HasValue)
+                return effectDescription.DrawDescription;
+
+            var (left, top, right, bottom) = trimRect.Value;
+
+            cropEffect.Rectangle = new Vector4(left, top, right, bottom);
+
+            float offsetX, offsetY;
+            if (item.Center)
+            {
+                offsetX = -(left + right) * 0.5f;
+                offsetY = -(top + bottom) * 0.5f;
+            }
+            else
+            {
+                offsetX = -left;
+                offsetY = -top;
+            }
+
+            translateEffect.TransformMatrix = new Matrix3x2(1f, 0f, 0f, 1f, offsetX, offsetY);
+
+            return effectDescription.DrawDescription;
+        }
+
+        private static (float Left, float Top, float Right, float Bottom)? ComputeTrimRect(
+            ID2D1DeviceContext context, ID2D1Image image)
+        {
+            var bounds = context.GetImageLocalBounds(image);
+            int width = (int)MathF.Ceiling(bounds.Right - bounds.Left);
+            int height = (int)MathF.Ceiling(bounds.Bottom - bounds.Top);
+
+            if (width <= 0 || height <= 0)
+                return null;
+
+            var gpuProps = new BitmapProperties1(
+                new PixelFormat(Vortice.DXGI.Format.B8G8R8A8_UNorm, AlphaMode.Premultiplied),
+                context.Dpi.Width,
+                context.Dpi.Height,
+                BitmapOptions.Target);
+
+            var cpuProps = new BitmapProperties1(
+                new PixelFormat(Vortice.DXGI.Format.B8G8R8A8_UNorm, AlphaMode.Premultiplied),
+                context.Dpi.Width,
+                context.Dpi.Height,
+                BitmapOptions.CpuRead | BitmapOptions.CannotDraw);
+
+            using var gpuBitmap = context.CreateBitmap(new SizeI(width, height), gpuProps);
+            using var cpuBitmap = context.CreateBitmap(new SizeI(width, height), cpuProps);
+
+            context.Target = gpuBitmap;
+            context.BeginDraw();
+            context.Clear(new Color4(0f, 0f, 0f, 0f));
+            context.DrawImage(
+                image,
+                new Vector2(-bounds.Left, -bounds.Top),
+                null,
+                InterpolationMode.NearestNeighbor,
+                CompositeMode.SourceCopy);
+            context.EndDraw();
+            context.Target = null;
+
+            cpuBitmap.CopyFromBitmap(gpuBitmap);
+
+            var map = cpuBitmap.Map(MapOptions.Read);
+            try
+            {
+                return FindOpaqueBounds(map, width, height, bounds.Left, bounds.Top);
+            }
+            finally
+            {
+                cpuBitmap.Unmap();
+            }
+        }
+
+        private static unsafe (float Left, float Top, float Right, float Bottom)? FindOpaqueBounds(
+            MappedRectangle map, int width, int height, float originX, float originY)
+        {
+            int minX = width, minY = height, maxX = -1, maxY = -1;
+            var ptr = (byte*)map.Bits;
+
+            for (int y = 0; y < height; y++)
+            {
+                var row = ptr + (long)y * map.Pitch;
+                for (int x = 0; x < width; x++)
+                {
+                    if (row[x * 4 + 3] == 0)
+                        continue;
+
+                    if (x < minX) minX = x;
+                    if (x > maxX) maxX = x;
+                    if (y < minY) minY = y;
+                    if (y > maxY) maxY = y;
+                }
+            }
+
+            if (maxX < 0)
+                return null;
+
+            return (
+                originX + minX,
+                originY + minY,
+                originX + maxX + 1f,
+                originY + maxY + 1f);
+        }
+
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            cropEffect = new Crop(devices.DeviceContext);
+            disposer.Collect(cropEffect);
+
+            var cropOutput = cropEffect.Output;
+            disposer.Collect(cropOutput);
+
+            translateEffect = new AffineTransform2D(devices.DeviceContext);
+            disposer.Collect(translateEffect);
+
+            translateEffect.SetInput(0, cropOutput, true);
+
+            var output = translateEffect.Output;
+            disposer.Collect(output);
+            return output;
+        }
+
+        protected override void setInput(ID2D1Image? input)
+        {
+            currentInput = input;
+            cropEffect?.SetInput(0, input, true);
+        }
+
+        protected override void ClearEffectChain()
+        {
+            currentInput = null;
+            cropEffect?.SetInput(0, null, true);
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
@@ -19,6 +19,11 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
         AffineTransform2D? translateEffect;
         ID2D1Image? currentInput;
 
+        bool hasCache;
+        ID2D1Image? cachedInput;
+        Rect cachedBounds;
+        (float Left, float Top, float Right, float Bottom)? cachedTrimRect;
+
         public TrimMarginEffectProcessor(IGraphicsDevicesAndContext devices, TrimMarginEffect item) : base(devices)
         {
             this.item = item;
@@ -31,7 +36,22 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
             if (IsPassThroughEffect || cropEffect is null || translateEffect is null || currentInput is null)
                 return effectDescription.DrawDescription;
 
-            var trimRect = ComputeTrimRect(isolatedContext, currentInput);
+            var bounds = isolatedContext.GetImageLocalBounds(currentInput);
+
+            (float Left, float Top, float Right, float Bottom)? trimRect;
+            if (hasCache && ReferenceEquals(cachedInput, currentInput) && cachedBounds.Equals(bounds))
+            {
+                trimRect = cachedTrimRect;
+            }
+            else
+            {
+                trimRect = ComputeTrimRect(isolatedContext, currentInput, bounds);
+                cachedInput = currentInput;
+                cachedBounds = bounds;
+                cachedTrimRect = trimRect;
+                hasCache = true;
+            }
+
             if (!trimRect.HasValue)
                 return effectDescription.DrawDescription;
 
@@ -47,9 +67,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
         }
 
         private static (float Left, float Top, float Right, float Bottom)? ComputeTrimRect(
-            ID2D1DeviceContext context, ID2D1Image image)
+            ID2D1DeviceContext context, ID2D1Image image, Rect bounds)
         {
-            var bounds = context.GetImageLocalBounds(image);
             int width = (int)MathF.Ceiling(bounds.Right - bounds.Left);
             int height = (int)MathF.Ceiling(bounds.Bottom - bounds.Top);
 
@@ -155,6 +174,9 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
         {
             currentInput = null;
             cropEffect?.SetInput(0, null, true);
+            hasCache = false;
+            cachedInput = null;
+            cachedTrimRect = null;
         }
     }
 }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
@@ -12,8 +12,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
 {
     internal sealed class TrimMarginEffectProcessor : VideoEffectProcessorBase
     {
+        readonly IGraphicsDevicesAndContext devices;
         readonly TrimMarginEffect item;
-        readonly ID2D1DeviceContext isolatedContext;
 
         Crop? cropEffect;
         AffineTransform2D? translateEffect;
@@ -26,9 +26,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
 
         public TrimMarginEffectProcessor(IGraphicsDevicesAndContext devices, TrimMarginEffect item) : base(devices)
         {
+            this.devices = devices;
             this.item = item;
-            isolatedContext = devices.DeviceContext.Device.CreateDeviceContext(DeviceContextOptions.None);
-            disposer.Collect(isolatedContext);
         }
 
         public override DrawDescription Update(EffectDescription effectDescription)
@@ -36,7 +35,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
             if (IsPassThroughEffect || cropEffect is null || translateEffect is null || currentInput is null)
                 return effectDescription.DrawDescription;
 
-            var bounds = isolatedContext.GetImageLocalBounds(currentInput);
+            var dc = devices.DeviceContext;
+            var bounds = dc.GetImageLocalBounds(currentInput);
 
             (float Left, float Top, float Right, float Bottom)? trimRect;
             if (hasCache && ReferenceEquals(cachedInput, currentInput) && cachedBounds.Equals(bounds))
@@ -45,7 +45,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
             }
             else
             {
-                trimRect = ComputeTrimRect(isolatedContext, currentInput, bounds);
+                trimRect = ComputeTrimRect(dc, currentInput, bounds);
                 cachedInput = currentInput;
                 cachedBounds = bounds;
                 cachedTrimRect = trimRect;

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
@@ -155,7 +155,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
             disposer.Collect(translateEffect);
 
             using(var cropOutput = cropEffect.Output)
-            translateEffect.SetInput(0, cropOutput, true);
+                translateEffect.SetInput(0, cropOutput, true);
 
             var output = translateEffect.Output;
             disposer.Collect(output);
@@ -172,6 +172,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
         {
             currentInput = null;
             cropEffect?.SetInput(0, null, true);
+            translateEffect?.SetInput(0, null, true);
             hasCache = false;
             cachedInput = null;
             cachedTrimRect = null;

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
@@ -151,12 +151,10 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
             cropEffect = new Crop(devices.DeviceContext);
             disposer.Collect(cropEffect);
 
-            var cropOutput = cropEffect.Output;
-            disposer.Collect(cropOutput);
-
             translateEffect = new AffineTransform2D(devices.DeviceContext);
             disposer.Collect(translateEffect);
 
+            using(var cropOutput = cropEffect.Output)
             translateEffect.SetInput(0, cropOutput, true);
 
             var output = translateEffect.Output;

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
@@ -39,19 +39,9 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
 
             cropEffect.Rectangle = new Vector4(left, top, right, bottom);
 
-            float offsetX, offsetY;
-            if (item.Center)
-            {
-                offsetX = -(left + right) * 0.5f;
-                offsetY = -(top + bottom) * 0.5f;
-            }
-            else
-            {
-                offsetX = -left;
-                offsetY = -top;
-            }
-
-            translateEffect.TransformMatrix = new Matrix3x2(1f, 0f, 0f, 1f, offsetX, offsetY);
+            translateEffect.TransformMatrix = item.Center
+                ? new Matrix3x2(1f, 0f, 0f, 1f, -(left + right) * 0.5f, -(top + bottom) * 0.5f)
+                : Matrix3x2.Identity;
 
             return effectDescription.DrawDescription;
         }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/TrimMargin/TrimMarginEffectProcessor.cs
@@ -16,7 +16,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
         readonly TrimMarginEffect item;
 
         Crop? cropEffect;
-        AffineTransform2D? translateEffect;
+        AffineTransform2D? transformEffect;
         ID2D1Image? currentInput;
 
         bool hasCache;
@@ -32,7 +32,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
 
         public override DrawDescription Update(EffectDescription effectDescription)
         {
-            if (IsPassThroughEffect || cropEffect is null || translateEffect is null || currentInput is null)
+            if (IsPassThroughEffect || cropEffect is null || transformEffect is null || currentInput is null)
                 return effectDescription.DrawDescription;
 
             var dc = devices.DeviceContext;
@@ -59,7 +59,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
 
             cropEffect.Rectangle = new Vector4(left, top, right, bottom);
 
-            translateEffect.TransformMatrix = item.Center
+            transformEffect.TransformMatrix = item.Center
                 ? new Matrix3x2(1f, 0f, 0f, 1f, -(left + right) * 0.5f, -(top + bottom) * 0.5f)
                 : Matrix3x2.Identity;
 
@@ -151,13 +151,13 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
             cropEffect = new Crop(devices.DeviceContext);
             disposer.Collect(cropEffect);
 
-            translateEffect = new AffineTransform2D(devices.DeviceContext);
-            disposer.Collect(translateEffect);
+            transformEffect = new AffineTransform2D(devices.DeviceContext);
+            disposer.Collect(transformEffect);
 
             using(var cropOutput = cropEffect.Output)
-                translateEffect.SetInput(0, cropOutput, true);
+                transformEffect.SetInput(0, cropOutput, true);
 
-            var output = translateEffect.Output;
+            var output = transformEffect.Output;
             disposer.Collect(output);
             return output;
         }
@@ -172,7 +172,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.TrimMargin
         {
             currentInput = null;
             cropEffect?.SetInput(0, null, true);
-            translateEffect?.SetInput(0, null, true);
+            transformEffect?.SetInput(0, null, true);
             hasCache = false;
             cachedInput = null;
             cachedTrimRect = null;


### PR DESCRIPTION
## PRの種類
<!-- 該当するものに [x] を付けてください -->
- [x] 新機能の追加 → **`develop` ブランチ宛**にお願いします
- [ ] リリース済み機能のバグ修正 → **`master` ブランチ宛**にお願いします

## 概要
<!-- 変更内容を簡単に記載してください -->

映像の透明ピクセルを走査して不透明領域を自動検出し、余白をトリミングする映像エフェクトを追加しました。