### PR TITLE
LUT適用でタイル境界アーティファクトを修正しR16G16B16A16_Floatを利用するように修正

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Lut/CubeLutTextureFactory.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Lut/CubeLutTextureFactory.cs
@@ -15,7 +15,7 @@ internal static class CubeLutTextureFactory
             var n = lut.Size3D;
             var width = n * n;
             var height = n;
-            var pixels = new byte[width * height * 4];
+            var pixels = new ushort[width * height * 4];
             var data = lut.HasShaper ? ComposeWithShaper(lut) : lut.Data3D;
 
             for (var b = 0; b < n; b++)
@@ -29,10 +29,10 @@ internal static class CubeLutTextureFactory
                         var dstY = g;
                         var dstIndex = (dstY * width + dstX) * 4;
 
-                        pixels[dstIndex + 0] = ToByte(data[srcIndex + 2]); // B
-                        pixels[dstIndex + 1] = ToByte(data[srcIndex + 1]); // G
-                        pixels[dstIndex + 2] = ToByte(data[srcIndex + 0]); // R
-                        pixels[dstIndex + 3] = 255;
+                        pixels[dstIndex + 0] = ToHalf(data[srcIndex + 0]);
+                        pixels[dstIndex + 1] = ToHalf(data[srcIndex + 1]);
+                        pixels[dstIndex + 2] = ToHalf(data[srcIndex + 2]);
+                        pixels[dstIndex + 3] = OneHalf;
                     }
                 }
             }
@@ -52,7 +52,7 @@ internal static class CubeLutTextureFactory
             const int n = 2;
             const int width = n * n;
             const int height = n;
-            var pixels = new byte[width * height * 4];
+            var pixels = new ushort[width * height * 4];
 
             for (var b = 0; b < n; b++)
             {
@@ -64,11 +64,10 @@ internal static class CubeLutTextureFactory
                         var dstY = g;
                         var dstIndex = (dstY * width + dstX) * 4;
 
-                        // B8G8R8A8_UNorm: memory order B, G, R, A
-                        pixels[dstIndex + 0] = (byte)(b == 0 ? 0 : 255); // B
-                        pixels[dstIndex + 1] = (byte)(g == 0 ? 0 : 255); // G
-                        pixels[dstIndex + 2] = (byte)(r == 0 ? 0 : 255); // R
-                        pixels[dstIndex + 3] = 255;
+                        pixels[dstIndex + 0] = r == 0 ? ZeroHalf : OneHalf;
+                        pixels[dstIndex + 1] = g == 0 ? ZeroHalf : OneHalf;
+                        pixels[dstIndex + 2] = b == 0 ? ZeroHalf : OneHalf;
+                        pixels[dstIndex + 3] = OneHalf;
                     }
                 }
             }
@@ -105,14 +104,12 @@ internal static class CubeLutTextureFactory
         return composed;
     }
 
-    private static byte ToByte(float v)
-    {
-        if (v <= 0f) return 0;
-        if (v >= 1f) return 255;
-        return (byte)MathF.Round(v * 255f);
-    }
+    private const ushort ZeroHalf = 0x0000;
+    private const ushort OneHalf = 0x3C00;
 
-    private static ID2D1Bitmap CreateD2DBitmap(ID2D1DeviceContext deviceContext, byte[] pixels, int width, int height)
+    private static ushort ToHalf(float value) => BitConverter.HalfToUInt16Bits((Half)value);
+
+    private static ID2D1Bitmap CreateD2DBitmap(ID2D1DeviceContext deviceContext, ushort[] pixels, int width, int height)
     {
         var handle = GCHandle.Alloc(pixels, GCHandleType.Pinned);
         try
@@ -120,11 +117,11 @@ internal static class CubeLutTextureFactory
             var size = new Vortice.Mathematics.SizeI(width, height);
             var props = new BitmapProperties1(
                 new Vortice.DCommon.PixelFormat(
-                    Vortice.DXGI.Format.B8G8R8A8_UNorm,
+                    Vortice.DXGI.Format.R16G16B16A16_Float,
                     Vortice.DCommon.AlphaMode.Premultiplied),
                 96f, 96f, BitmapOptions.None);
             return ((ID2D1DeviceContext1)deviceContext).CreateBitmap(
-                size, handle.AddrOfPinnedObject(), width * 4, props);
+                size, handle.AddrOfPinnedObject(), width * 8, props);
         }
         finally
         {

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Lut/LutCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Lut/LutCustomEffect.cs
@@ -168,8 +168,14 @@ public sealed class LutCustomEffect(IGraphicsDevicesAndContext devices)
             RawRect outputRect,
             RawRect[] inputRects)
         {
-            if (inputRects.Length > 0) inputRects[0] = outputRect;
-            if (inputRects.Length > 1) inputRects[1] = new RawRect(-65536, -65536, 65536, 65536);
+            if (inputRects.Length > 0)
+                inputRects[0] = outputRect;
+            if (inputRects.Length > 1)
+            {
+                var width = (int)MathF.Max(1f, _cb.AtlasWidth);
+                var height = (int)MathF.Max(1f, _cb.AtlasHeight);
+                inputRects[1] = new RawRect(0, 0, width, height);
+            }
         }
 
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
## PRの種類
<!-- 該当するものに [x] を付けてください -->
- [x] 新機能の追加 → **`develop` ブランチ宛**にお願いします
- [ ] リリース済み機能のバグ修正 → **`master` ブランチ宛**にお願いします

## 概要
<!-- 変更内容を簡単に記載してください -->

LUTエフェクトを巨大な画像に適用した際、Direct2Dが内部でエフェクトをタイル分割すると、タイル境界に色のクラックアーティファクトが発生する問題を解決しました。

MapOutputRectToInputRectsでLUT入力にRawRect(-65536, -65536, 65536, 65536)の無限矩形を指定していたため、Direct2DがLUTをシーン空間全体を覆う巨大な画像と解釈し、ソース画像のタイル化に巻き込んでLUTもタイル毎に部分バインドしてしまっていました。結果、シェーダーが計算する絶対UVがタイル境界でLUTの誤テクセルを参照していました。

## 修正

MapOutputRectToInputRectsでLUT入力にRawRect(0, 0, AtlasWidth, AtlasHeight)という実サイズと完全一致した正確な矩形を指定。

LUTテクスチャのフォーマットをB8G8R8A8_UNormからR16G16B16A16_Floatへ変更。Half型で書き込み、量子化誤差を完全に排除。