### PR TITLE
ブラウザツールでクラッシュ時の例外とダイアログの問題を修正

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserView.xaml
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserView.xaml
@@ -20,6 +20,13 @@
         <webview2:CoreWebView2CreationProperties x:Key="DummyWebViewCreationProperties" BrowserExecutableFolder="C:\dummy"/>
         <webview2:CoreWebView2CreationProperties x:Key="WebViewCreationProperties" UserDataFolder="{x:Static local:BrowserViewModel.UserDataFolderPath}" AreBrowserExtensionsEnabled="True" AdditionalBrowserArguments="{Binding Path=AdditionalBrowserArguments, Source={x:Static local:BrowserSettings.Default}}"/>
         <local:FilePathToImageConverter x:Key="FilePathToImageConverter"/>
+        <Style x:Key="WebViewStyle" TargetType="webview2:WebView2">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsFailedToInitializeWebView2}" Value="True">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
     </UserControl.Resources>
     <i:Interaction.Behaviors>
         <pb:DialogBehavior Content="{Binding FavoriteEditorViewModel}" IsModal="True">
@@ -286,17 +293,7 @@
             </c:DropDownButton>
         </Grid>
 
-        <webview2:WebView2 Grid.Row="1" x:Name="webView" CreationProperties="{StaticResource WebViewCreationProperties}">
-            <webview2:WebView2.Style>
-                <Style TargetType="webview2:WebView2">
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsFailedToInitializeWebView2}" Value="True">
-                            <Setter Property="Visibility" Value="Collapsed"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </webview2:WebView2.Style>
-        </webview2:WebView2>
+        <Grid Grid.Row="1" x:Name="webViewHost"/>
 
         <ProgressBar Grid.Row="0" Height="2" VerticalAlignment="Bottom" Value="{Binding LoadingProgress, Mode=OneWay}" Maximum="100">
             <ProgressBar.Style>

--- a/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserView.xaml
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserView.xaml
@@ -24,9 +24,10 @@
     <i:Interaction.Behaviors>
         <pb:DialogBehavior Content="{Binding FavoriteEditorViewModel}" IsModal="True">
             <pb:DialogBehavior.Style>
-                <Style TargetType="Window">
+                <Style TargetType="Window" BasedOn="{StaticResource {x:Type Window}}">
                     <Setter Property="Title" Value="{x:Static local:Texts.EditFavorite}"/>
                     <Setter Property="SizeToContent" Value="WidthAndHeight"/>
+                    <Setter Property="ResizeMode" Value="NoResize"/>
                 </Style>
             </pb:DialogBehavior.Style>
             <pb:DialogBehavior.ContentTemplate>
@@ -40,6 +41,7 @@
                 <Style TargetType="Window" BasedOn="{StaticResource {x:Type Window}}">
                     <Setter Property="Title" Value="{x:Static local:Texts.ClearBrowsingData}"/>
                     <Setter Property="SizeToContent" Value="WidthAndHeight"/>
+                    <Setter Property="ResizeMode" Value="NoResize"/>
                 </Style>
             </pb:DialogBehavior.Style>
             <pb:DialogBehavior.ContentTemplate>
@@ -54,6 +56,7 @@
                     <Setter Property="Title" Value="{x:Static local:Texts.BrowserSettings}"/>
                     <Setter Property="Width" Value="500"/>
                     <Setter Property="Height" Value="300"/>
+                    <Setter Property="ResizeMode" Value="NoResize"/>
                 </Style>
             </pb:DialogBehavior.Style>
             <pb:DialogBehavior.ContentTemplate>
@@ -101,7 +104,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        
+
         <Grid Grid.Row="0" Name="toolBar" Height="26">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>

--- a/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserView.xaml.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserView.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.Web.WebView2.Wpf;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -8,31 +9,76 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
     /// </summary>
     public partial class BrowserView : UserControl
     {
+        WebView2 webView;
+
         public BrowserView()
         {
             InitializeComponent();
 
+            webView = CreateWebView2();
+            webViewHost.Children.Add(webView);
+
             DataContextChanged += BrowserView_DataContextChanged;
+        }
+
+        private WebView2 CreateWebView2()
+        {
+            return new WebView2
+            {
+                CreationProperties = (CoreWebView2CreationProperties)FindResource("WebViewCreationProperties"),
+                Style = (Style)FindResource("WebViewStyle"),
+            };
         }
 
         private async void BrowserView_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if (e.OldValue is BrowserViewModel oldVm)
+            {
+                oldVm.RecreateWebViewRequested -= ViewModel_RecreateWebViewRequested;
                 oldVm.DetachWebView2();
+            }
             if (e.NewValue is BrowserViewModel newVm)
             {
-                try
-                {
-                    await webView.EnsureCoreWebView2Async();
-                    if (!ReferenceEquals(DataContext, newVm))
-                        return;
-                    newVm.AttachWebView2(webView);
-                }
-                catch(Exception ex)
-                {
-                    newVm.FailToInitializeWebView2(Texts.FailedToInitializeBrowser + "\r\n\r\n" + ex.Message);
-                }
+                newVm.RecreateWebViewRequested += ViewModel_RecreateWebViewRequested;
+                await InitializeWebView2Async(newVm);
             }
+        }
+
+        private async void ViewModel_RecreateWebViewRequested(object? sender, EventArgs e)
+        {
+            if (DataContext is not BrowserViewModel vm || !ReferenceEquals(sender, vm))
+                return;
+            // CoreWebView2.ProcessFailed のコールスタック内でコントロールを破棄すると不安定なため、抜けてから再生成する
+            await Task.Yield();
+            if (!ReferenceEquals(DataContext, vm))
+                return;
+            RecreateWebView2Control();
+            await InitializeWebView2Async(vm);
+        }
+
+        private async Task InitializeWebView2Async(BrowserViewModel vm)
+        {
+            try
+            {
+                await webView.EnsureCoreWebView2Async();
+                if (!ReferenceEquals(DataContext, vm))
+                    return;
+                vm.AttachWebView2(webView);
+            }
+            catch (Exception ex)
+            {
+                vm.FailToInitializeWebView2(Texts.FailedToInitializeBrowser + "\r\n\r\n" + ex.Message);
+            }
+        }
+
+        private void RecreateWebView2Control()
+        {
+            var oldWebView = webView;
+            webViewHost.Children.Remove(oldWebView);
+            oldWebView.Dispose();
+
+            webView = CreateWebView2();
+            webViewHost.Children.Add(webView);
         }
     }
 }

--- a/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserViewModel.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserViewModel.cs
@@ -102,7 +102,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
                 _ => !isBrowserCrashed && webView2 != null,
                 parameter => ExecuteNavigate(parameter));
             OpenFavoriteEditorCommand = new ActionCommand(
-                _ => true,
+                _ => !isBrowserCrashed && webView2 != null,
                 parameter => ExecuteOpenFavoriteEditor(parameter));
             ClearBrowsingDataCommand = new ActionCommand(
                 _ => !isBrowserCrashed && webView2?.CoreWebView2?.Profile != null,

--- a/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserViewModel.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserViewModel.cs
@@ -27,6 +27,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
         static string? defaultUserAgent;
 
         public event EventHandler<CreateNewToolViewRequestedEventArgs>? CreateNewToolViewRequested;
+        public event EventHandler? RecreateWebViewRequested;
 
         public bool IsFailedToInitializeWebView2 { get; private set; }
         public string FailedToInitializeWebView2Message { get; private set; } = string.Empty;
@@ -265,6 +266,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
                 core.ScriptDialogOpening += CoreWebView2_ScriptDialogOpening;
             }
 
+            BrowserSettings.Default.PropertyChanged -= BrowserSettings_PropertyChanged;
             BrowserSettings.Default.PropertyChanged += BrowserSettings_PropertyChanged;
 
             ApplySettings();
@@ -463,7 +465,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
             catch { }
         }
 
-        private async void CoreWebView2_ProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
+        private void CoreWebView2_ProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
         {
             if (e.ProcessFailedKind != CoreWebView2ProcessFailedKind.BrowserProcessExited)
                 return;
@@ -473,43 +475,14 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
             progressCts?.Cancel();
             UpdateCommandCanExecuteState();
 
-            if (isDetached || webView2 is not { } wv2)
-                return;
-
             if (sender is CoreWebView2 crashedCore)
                 UnsubscribeCoreWebView2Events(crashedCore);
 
-            try
-            {
-                await wv2.EnsureCoreWebView2Async();
-            }
-            catch
-            {
-                return;
-            }
-
-            if (isDetached || !ReferenceEquals(webView2, wv2))
+            if (isDetached)
                 return;
 
-            CoreWebView2? newCore;
-            try
-            {
-                newCore = wv2.CoreWebView2;
-            }
-            catch
-            {
-                return;
-            }
-
-            isBrowserCrashed = false;
-            newCore.IsMuted = false;
-            defaultUserAgent ??= newCore.Settings.UserAgent;
-            SubscribeCoreWebView2Events(newCore);
-            newCore.ScriptDialogOpening -= CoreWebView2_ScriptDialogOpening;
-            newCore.ScriptDialogOpening += CoreWebView2_ScriptDialogOpening;
-            ApplySettings();
-            ApplyState();
-            UpdateCommandCanExecuteState();
+            // BrowserProcessExited 後は同一コントロールを再初期化しても新しいブラウザプロセスは作られないため、View にコントロールごとの再生成を要求する
+            RecreateWebViewRequested?.Invoke(this, EventArgs.Empty);
         }
 
         private void AddHistory(string url, string title)

--- a/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserViewModel.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserViewModel.cs
@@ -96,7 +96,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
                 _ => !isBrowserCrashed && webView2 != null && !IsLoading,
                 _ => webView2?.CoreWebView2?.Reload());
             StopCommand = new ActionCommand(
-                _ => webView2 != null && IsLoading,
+                _ => !isBrowserCrashed && webView2 != null && IsLoading,
                 _ => webView2?.CoreWebView2?.Stop());
             NavigateCommand = new ActionCommand(
                 _ => !isBrowserCrashed && webView2 != null,

--- a/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserViewModel.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserViewModel.cs
@@ -481,6 +481,10 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
             if (isDetached)
                 return;
 
+            // 復旧後の AttachWebView2 → ApplyState でクラッシュ直前のページ・ズームへ戻れるよう state を更新する
+            if (!string.IsNullOrEmpty(Location))
+                state = new WebBrowserSavedState(Location, webView2?.ZoomFactor ?? state.Zoom);
+
             // BrowserProcessExited 後は同一コントロールを再初期化しても新しいブラウザプロセスは作られないため、View にコントロールごとの再生成を要求する
             RecreateWebViewRequested?.Invoke(this, EventArgs.Empty);
         }

--- a/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserViewModel.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Browser/BrowserViewModel.cs
@@ -16,6 +16,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
         TaskCompletionSource<WebView2>? webView2TCS;
         WebView2? webView2;
         bool isDetached;
+        bool isBrowserCrashed;
         public bool IsLoading { get => field; private set => Set(ref field, value); }
         public double LoadingProgress { get => field; private set => Set(ref field, value); }
         CancellationTokenSource? progressCts;
@@ -36,7 +37,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
             get => field;
             set
             {
-                if (Set(ref field, value) && webView2?.CoreWebView2 is { } core)
+                if (Set(ref field, value) && !isBrowserCrashed && webView2?.CoreWebView2 is { } core)
                 {
                     core.Settings.UserAgent = value ? MobileUserAgent : (defaultUserAgent ?? string.Empty);
                     core.Reload();
@@ -86,37 +87,37 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
                 _ => true,
                 _ => ExecuteCreateNewWindow());
             GoBackCommand = new ActionCommand(
-                _ => webView2?.CoreWebView2?.CanGoBack ?? false,
+                _ => !isBrowserCrashed && (webView2?.CoreWebView2?.CanGoBack ?? false),
                 _ => webView2?.CoreWebView2?.GoBack());
             GoForwardCommand = new ActionCommand(
-                _ => webView2?.CoreWebView2?.CanGoForward ?? false,
+                _ => !isBrowserCrashed && (webView2?.CoreWebView2?.CanGoForward ?? false),
                 _ => webView2?.CoreWebView2?.GoForward());
             RefreshCommand = new ActionCommand(
-                _ => webView2 != null && !IsLoading,
+                _ => !isBrowserCrashed && webView2 != null && !IsLoading,
                 _ => webView2?.CoreWebView2?.Reload());
             StopCommand = new ActionCommand(
                 _ => webView2 != null && IsLoading,
                 _ => webView2?.CoreWebView2?.Stop());
             NavigateCommand = new ActionCommand(
-                _ => webView2 != null,
+                _ => !isBrowserCrashed && webView2 != null,
                 parameter => ExecuteNavigate(parameter));
             OpenFavoriteEditorCommand = new ActionCommand(
                 _ => true,
                 parameter => ExecuteOpenFavoriteEditor(parameter));
             ClearBrowsingDataCommand = new ActionCommand(
-                _ => webView2?.CoreWebView2?.Profile != null,
+                _ => !isBrowserCrashed && webView2?.CoreWebView2?.Profile != null,
                 _ => ExecuteClearBrowsingData());
             OpenBrowserSettingsCommand = new ActionCommand(
                 _ => true,
                 _ => ExecuteOpenBrowserSettings());
             DownloadCommand = new ActionCommand(
-                _ => webView2?.CoreWebView2 != null,
+                _ => !isBrowserCrashed && webView2?.CoreWebView2 != null,
                 _ => webView2?.CoreWebView2?.OpenDefaultDownloadDialog());
             PrintCommand = new ActionCommand(
-                _ => webView2?.CoreWebView2 != null,
+                _ => !isBrowserCrashed && webView2?.CoreWebView2 != null,
                 _ => webView2?.CoreWebView2?.ShowPrintUI());
             FindCommand = new ActionCommand(
-                _ => webView2?.CoreWebView2 != null,
+                _ => !isBrowserCrashed && webView2?.CoreWebView2 != null,
                 async _ => await ExecuteFindAsync());
         }
 
@@ -135,6 +136,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
 
         private void ExecuteNavigate(object? parameter)
         {
+            if (isBrowserCrashed)
+                return;
             var url = NormalizeOrCreateSearchUrl(parameter as string ?? string.Empty);
             if (NormalizeUrl(webView2?.CoreWebView2?.Source ?? string.Empty) == url)
                 return;
@@ -171,12 +174,12 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
 
         private void ExecuteClearBrowsingData()
         {
-            if (webView2?.CoreWebView2?.Profile == null)
+            if (isBrowserCrashed || webView2?.CoreWebView2?.Profile == null)
                 return;
 
             ClearBrowsingDataViewModel = new ClearBrowsingDataViewModel(async vm =>
             {
-                if (vm.ClearBrowserCache && webView2?.CoreWebView2?.Profile is { } profile)
+                if (vm.ClearBrowserCache && !isBrowserCrashed && webView2?.CoreWebView2?.Profile is { } profile)
                 {
                     await profile.ClearBrowsingDataAsync();
                 }
@@ -202,7 +205,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
 
         private async Task ExecuteFindAsync()
         {
-            if (webView2?.CoreWebView2 is not { } core || core.Environment == null)
+            if (isBrowserCrashed || webView2?.CoreWebView2 is not { } core || core.Environment == null)
                 return;
 
             try
@@ -221,24 +224,43 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
             }
         }
 
+        void SubscribeCoreWebView2Events(CoreWebView2 core)
+        {
+            core.NewWindowRequested += CoreWebView2_NewWindowRequested;
+            core.NavigationStarting += CoreWebView2_NavigationStarting;
+            core.ContentLoading += CoreWebView2_ContentLoading;
+            core.DOMContentLoaded += CoreWebView2_DOMContentLoaded;
+            core.NavigationCompleted += CoreWebView2_NavigationCompleted;
+            core.SourceChanged += CoreWebView2_SourceChanged;
+            core.DocumentTitleChanged += CoreWebView2_DocumentTitleChanged;
+            core.FaviconChanged += CoreWebView2_FaviconChanged;
+            core.ProcessFailed += CoreWebView2_ProcessFailed;
+        }
+
+        void UnsubscribeCoreWebView2Events(CoreWebView2 core)
+        {
+            core.NewWindowRequested -= CoreWebView2_NewWindowRequested;
+            core.NavigationStarting -= CoreWebView2_NavigationStarting;
+            core.ContentLoading -= CoreWebView2_ContentLoading;
+            core.DOMContentLoaded -= CoreWebView2_DOMContentLoaded;
+            core.NavigationCompleted -= CoreWebView2_NavigationCompleted;
+            core.SourceChanged -= CoreWebView2_SourceChanged;
+            core.DocumentTitleChanged -= CoreWebView2_DocumentTitleChanged;
+            core.FaviconChanged -= CoreWebView2_FaviconChanged;
+            core.ProcessFailed -= CoreWebView2_ProcessFailed;
+        }
+
         public void AttachWebView2(WebView2 webView2Service)
         {
             webView2 = webView2Service;
             isDetached = false;
+            isBrowserCrashed = false;
 
             if (webView2.CoreWebView2 is { } core)
             {
                 core.IsMuted = false;
                 defaultUserAgent ??= core.Settings.UserAgent;
-                core.NewWindowRequested += CoreWebView2_NewWindowRequested;
-                core.NavigationStarting += CoreWebView2_NavigationStarting;
-                core.ContentLoading += CoreWebView2_ContentLoading;
-                core.DOMContentLoaded += CoreWebView2_DOMContentLoaded;
-                core.NavigationCompleted += CoreWebView2_NavigationCompleted;
-                core.SourceChanged += CoreWebView2_SourceChanged;
-                core.DocumentTitleChanged += CoreWebView2_DocumentTitleChanged;
-                core.FaviconChanged += CoreWebView2_FaviconChanged;
-
+                SubscribeCoreWebView2Events(core);
                 core.ScriptDialogOpening -= CoreWebView2_ScriptDialogOpening;
                 core.ScriptDialogOpening += CoreWebView2_ScriptDialogOpening;
             }
@@ -258,22 +280,20 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
         {
             isDetached = true;
 
-            if (webView2?.CoreWebView2 is { } core)
+            if (webView2 is { } wv2 && !isBrowserCrashed)
             {
-                core.NewWindowRequested -= CoreWebView2_NewWindowRequested;
-                core.NavigationStarting -= CoreWebView2_NavigationStarting;
-                core.ContentLoading -= CoreWebView2_ContentLoading;
-                core.DOMContentLoaded -= CoreWebView2_DOMContentLoaded;
-                core.NavigationCompleted -= CoreWebView2_NavigationCompleted;
-                core.SourceChanged -= CoreWebView2_SourceChanged;
-                core.DocumentTitleChanged -= CoreWebView2_DocumentTitleChanged;
-                core.FaviconChanged -= CoreWebView2_FaviconChanged;
+                CoreWebView2? core = null;
+                try { core = wv2.CoreWebView2; }
+                catch (InvalidOperationException) { }
 
-                core.IsMuted = true;
-                core.ExecuteScriptAsync("window.onbeforeunload = null; document.querySelectorAll('video, audio').forEach(x => x.pause());");
-                core.Navigate("about:blank");
-
-                core.ScriptDialogOpening -= CoreWebView2_ScriptDialogOpening;
+                if (core is not null)
+                {
+                    UnsubscribeCoreWebView2Events(core);
+                    core.IsMuted = true;
+                    core.ExecuteScriptAsync("window.onbeforeunload = null; document.querySelectorAll('video, audio').forEach(x => x.pause());");
+                    core.Navigate("about:blank");
+                    core.ScriptDialogOpening -= CoreWebView2_ScriptDialogOpening;
+                }
             }
 
             BrowserSettings.Default.PropertyChanged -= BrowserSettings_PropertyChanged;
@@ -391,7 +411,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
             IsLoading = false;
             LoadingProgress = 0;
             UpdateCommandCanExecuteState();
-            if (webView2?.CoreWebView2 is not { } core)
+            if (isBrowserCrashed || webView2?.CoreWebView2 is not { } core)
                 return;
             AddHistory(core.Source, core.DocumentTitle);
             var url = core.Source;
@@ -412,6 +432,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
 
         private void CoreWebView2_SourceChanged(object? sender, CoreWebView2SourceChangedEventArgs e)
         {
+            if (isBrowserCrashed)
+                return;
             Location = NormalizeUrl(webView2?.CoreWebView2?.Source ?? string.Empty);
             OnPropertyChanged(nameof(IsFavorite));
             UpdateCommandCanExecuteState();
@@ -424,7 +446,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
 
         private async void CoreWebView2_FaviconChanged(object? sender, object e)
         {
-            if (webView2?.CoreWebView2 is not { } core || string.IsNullOrEmpty(core.FaviconUri)) return;
+            if (isBrowserCrashed || webView2?.CoreWebView2 is not { } core || string.IsNullOrEmpty(core.FaviconUri)) return;
             var url = core.Source;
             var favorites = BrowserSettings.Default.Favorites;
             if (!favorites.Any(f => Uri.TryCreate(f.Url, UriKind.Absolute, out var fUri) && Uri.TryCreate(url, UriKind.Absolute, out var uUri) && string.Equals(fUri.Host, uUri.Host, StringComparison.OrdinalIgnoreCase)))
@@ -439,6 +461,55 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
                 }
             }
             catch { }
+        }
+
+        private async void CoreWebView2_ProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
+        {
+            if (e.ProcessFailedKind != CoreWebView2ProcessFailedKind.BrowserProcessExited)
+                return;
+
+            isBrowserCrashed = true;
+            IsLoading = false;
+            progressCts?.Cancel();
+            UpdateCommandCanExecuteState();
+
+            if (isDetached || webView2 is not { } wv2)
+                return;
+
+            if (sender is CoreWebView2 crashedCore)
+                UnsubscribeCoreWebView2Events(crashedCore);
+
+            try
+            {
+                await wv2.EnsureCoreWebView2Async();
+            }
+            catch
+            {
+                return;
+            }
+
+            if (isDetached || !ReferenceEquals(webView2, wv2))
+                return;
+
+            CoreWebView2? newCore;
+            try
+            {
+                newCore = wv2.CoreWebView2;
+            }
+            catch
+            {
+                return;
+            }
+
+            isBrowserCrashed = false;
+            newCore.IsMuted = false;
+            defaultUserAgent ??= newCore.Settings.UserAgent;
+            SubscribeCoreWebView2Events(newCore);
+            newCore.ScriptDialogOpening -= CoreWebView2_ScriptDialogOpening;
+            newCore.ScriptDialogOpening += CoreWebView2_ScriptDialogOpening;
+            ApplySettings();
+            ApplyState();
+            UpdateCommandCanExecuteState();
         }
 
         private void AddHistory(string url, string title)
@@ -463,7 +534,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
 
         private async Task FetchAndSaveFaviconAsync(string url)
         {
-            if (webView2?.CoreWebView2 is not { } core || string.IsNullOrEmpty(core.FaviconUri))
+            if (isBrowserCrashed || webView2?.CoreWebView2 is not { } core || string.IsNullOrEmpty(core.FaviconUri))
                 return;
             var favorites = BrowserSettings.Default.Favorites;
             if (!BrowserFaviconManager.IsFaviconMissingForMatchingFavorite(url, favorites))
@@ -515,10 +586,11 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
 
         private void ApplyState()
         {
+            if (isBrowserCrashed || webView2 == null)
+                return;
             var url = NormalizeOrCreateSearchUrl(state.Location);
-            webView2?.CoreWebView2?.Navigate(url);
-            if (webView2 != null)
-                webView2.ZoomFactor = state.Zoom;
+            webView2.CoreWebView2?.Navigate(url);
+            webView2.ZoomFactor = state.Zoom;
         }
 
         private void BrowserSettings_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -528,7 +600,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Tool.Browser
 
         private void ApplySettings()
         {
-            if (webView2?.CoreWebView2 is not { } core) return;
+            if (isBrowserCrashed || webView2?.CoreWebView2 is not { } core) return;
             var settings = core.Settings;
             settings.IsReputationCheckingRequired = BrowserSettings.Default.IsSmartScreenEnabled;
             settings.IsPasswordAutosaveEnabled = BrowserSettings.Default.IsPasswordAutosaveEnabled;


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [ ] このPRには1つの機能（または1つの修正）のみが含まれています

## 概要
<!-- 変更内容を簡単に記載してください -->

ブラウザのプロセスがクラッシュした際にCommandManager.RequerySuggestedの定期発火によってInvalidOperationExceptionが発生する問題を修正しました。
原因はGoBackCommandなどのCanExecute内でCoreWebView2プロパティにアクセスしていたことで、?.演算子はnullに対してしかショートサーキットしないため、クラッシュ後のプロセス無効状態では例外がそのまま伝播していました。
対応としてisBrowserCrashedフラグを導入し、CoreWebView2にアクセスする可能性のある全箇所をガードしました。またCoreWebView2.ProcessFailedイベントを購読し、BrowserProcessExitedを検知した際にはEnsureCoreWebView2Async()による再初期化と各種イベントの再購読・設定復元まで自動で行うようにしています。合わせてAttachWebView2・DetachWebView2・回復処理の三箇所で重複していたイベント管理コードをSubscribeCoreWebView2Events/UnsubscribeCoreWebView2Eventsに集約しました。
ダイアログ関連では、お気に入り編集ウィンドウのスタイルにBasedOn継承が抜けていた点と、全ダイアログでResizeModeが未設定のためリサイズできてしまっていた点を修正しています。後者はSizeToContentで決定したサイズが意図したサイズであるため、NoResizeを全ダイアログに統一して設定しました。

このPRはブラウザクラッシュ時の例外修正とダイアログの軽微な修正という2件の対応を含んでいます。ダイアログ側の変更は量が少なく独立したPRを立てるほどでもないと判断したため、まとめて対応しています。