### PR TITLE
エクスプローラーツールでお気に入り編集ウィンドウにBasedOn継承とNoResizeを追加

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Tool/Explorer/ExplorerView.xaml
+++ b/YukkuriMovieMaker.Plugin.Community/Tool/Explorer/ExplorerView.xaml
@@ -411,9 +411,10 @@
         <pb:MessageBoxBehavior ViewModel="{Binding MessageBoxViewModel,Mode=OneWay}"/>
         <pb:DialogBehavior Content="{Binding FavoriteEditorViewModel}" IsModal="True">
             <pb:DialogBehavior.Style>
-                <Style TargetType="Window">
+                <Style TargetType="Window" BasedOn="{StaticResource {x:Type Window}}">
                     <Setter Property="Title" Value="{x:Static local:Texts.EditFavorite}"/>
                     <Setter Property="SizeToContent" Value="WidthAndHeight"/>
+                    <Setter Property="ResizeMode" Value="NoResize"/>
                 </Style>
             </pb:DialogBehavior.Style>
             <pb:DialogBehavior.ContentTemplate>


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [x] このPRには1つの機能（または1つの修正）のみが含まれています

## 概要
<!-- 変更内容を簡単に記載してください -->

ExplorerView.xamlのお気に入り編集ダイアログで、BrowserView.xamlと同様の問題が残っていたため修正しました。
具体的にはStyleTargetType="Window"にBasedOn継承が設定されておらず、アプリケーションのウィンドウスタイルが適用されない状態でした。またResizeModeが未設定のため、SizeToContent="WidthAndHeight"でサイズが決定されているにも関わらずユーザーがリサイズできてしまっていました。
BrowserView.xamlでの修正と同一の方針で対応しています。