### PR TITLE
同色塗りつぶしでモード切替時にアルファマスクが更新されない問題を修正

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSameground/FillSamegroundEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSameground/FillSamegroundEffectProcessor.cs
@@ -196,7 +196,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSameground
                 || currentMode == FillSamegroundMode.PositionColor
                 || (UsesPosition(currentMode) && (posX != currentX || posY != currentY))
                 || (currentMode == FillSamegroundMode.Color && targetColor != currentTargetColor);
-            
+
             ID2D1Image? maskSource;
             if (needsMaskUpdate)
             {
@@ -222,7 +222,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSameground
                 return effectDescription.DrawDescription;
             }
 
-            if(isFirst || currentBlur != blur)
+            if(needsMaskUpdate || currentBlur != blur)
                 UpdateAlphaMask(maskSource, currentBlur);
             if(isFirst || currentOpacity != opacity)
                 opacityEffect.Value = (float)(Math.Clamp(currentOpacity, 0, 100) / 100.0);


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [x] このPRには1つの機能（または1つの修正）のみが含まれています
- [x] `YukkuriMovieMaker.dll`などYMM4本体の内部実装アセンブリを参照していません

## 概要
<!-- 変更内容を簡単に記載してください -->

needsMaskUpdateがtrueの場合もUpdateAlphaMaskを呼び出すよう条件を修正しました。
blur値が変化しないままモードを切り替えた際、maskSourceの参照が更新されてもalphaMaskEffectへの入力が古いままになっていました。