### PR TITLE
ウェーブクリッピングでランダムシードをGetHashCode()からRandom.Shared.Next()に修正

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/WaveClipping/WaveClippingEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/WaveClipping/WaveClippingEffect.cs
@@ -12,7 +12,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.WaveClipping
     {
         public override string Label => Texts.WaveClipping;
 
-        public float RandomSeed { get; } = (float)(Random.Shared.NextDouble());
+        internal int RandomSeed { get; } = Random.Shared.Next();
 
         [Display(GroupName = nameof(Texts.WaveClipping), Name = nameof(Texts.Mode), Description = nameof(Texts.ModeDescription), ResourceType = typeof(Texts))]
         [EnumComboBox]

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/WaveClipping/WaveClippingEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/WaveClipping/WaveClippingEffect.cs
@@ -12,6 +12,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.WaveClipping
     {
         public override string Label => Texts.WaveClipping;
 
+        public float RandomSeed { get; } = (float)(Random.Shared.NextDouble());
+
         [Display(GroupName = nameof(Texts.WaveClipping), Name = nameof(Texts.Mode), Description = nameof(Texts.ModeDescription), ResourceType = typeof(Texts))]
         [EnumComboBox]
         public WaveClippingMode Mode

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/WaveClipping/WaveClippingEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/WaveClipping/WaveClippingEffectProcessor.cs
@@ -25,8 +25,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.WaveClipping
         private int _randomSeed;
         private bool _useRandom;
 
-        private static float NormalizeHashCode(int hashCode)
-            => (uint)hashCode / (float)uint.MaxValue;
+        private static float NormalizeInt32ToUnitFloat(int value)
+            => (uint)value / (float)(uint.MaxValue + 1UL);
 
         public override DrawDescription Update(EffectDescription effectDescription)
         {
@@ -68,7 +68,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.WaveClipping
             if (_isFirst || _rotation != rotation)
                 _effect.Rotation = (float)rotation;
             if (_isFirst || _randomSeed != randomSeed)
-                _effect.RandomSeed = NormalizeHashCode(randomSeed);
+                _effect.RandomSeed = NormalizeInt32ToUnitFloat(randomSeed);
             if (_isFirst || _useRandom != useRandom)
                 _effect.UseRandom = useRandom ? 1.0f : 0.0f;
 

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/WaveClipping/WaveClippingEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/WaveClipping/WaveClippingEffectProcessor.cs
@@ -22,7 +22,6 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.WaveClipping
         private WaveClippingMode _mode;
         private bool _isInverted;
         private double _rotation;
-        private int _randomSeed;
         private bool _useRandom;
 
         private static float NormalizeInt32ToUnitFloat(int value)
@@ -46,7 +45,6 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.WaveClipping
             var mode = _item.Mode;
             var isInverted = _item.IsInverted;
             var rotation = -_item.Rotation.GetValue(frame, length, fps) * Math.PI / 180.0;
-            var randomSeed = _item.GetHashCode();
             var useRandom = _item.UseRandom;
 
             if (_isFirst || _amplitude != amplitude)
@@ -67,8 +65,6 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.WaveClipping
                 _effect.IsInverted = isInverted ? 1.0f : 0.0f;
             if (_isFirst || _rotation != rotation)
                 _effect.Rotation = (float)rotation;
-            if (_isFirst || _randomSeed != randomSeed)
-                _effect.RandomSeed = NormalizeInt32ToUnitFloat(randomSeed);
             if (_isFirst || _useRandom != useRandom)
                 _effect.UseRandom = useRandom ? 1.0f : 0.0f;
 
@@ -82,7 +78,6 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.WaveClipping
             _mode = mode;
             _isInverted = isInverted;
             _rotation = rotation;
-            _randomSeed = randomSeed;
             _useRandom = useRandom;
 
             return effectDescription.DrawDescription;
@@ -97,6 +92,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.WaveClipping
                 _effect = null;
                 return null;
             }
+            _effect.RandomSeed = NormalizeInt32ToUnitFloat(_item.RandomSeed);
             disposer.Collect(_effect);
 
             var output = _effect.Output;

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/WaveClipping/WaveClippingEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/WaveClipping/WaveClippingEffectProcessor.cs
@@ -25,6 +25,9 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.WaveClipping
         private int _randomSeed;
         private bool _useRandom;
 
+        private static float NormalizeHashCode(int hashCode)
+            => (uint)hashCode / (float)uint.MaxValue;
+
         public override DrawDescription Update(EffectDescription effectDescription)
         {
             if (IsPassThroughEffect || _effect is null)
@@ -65,7 +68,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.WaveClipping
             if (_isFirst || _rotation != rotation)
                 _effect.Rotation = (float)rotation;
             if (_isFirst || _randomSeed != randomSeed)
-                _effect.RandomSeed = randomSeed;
+                _effect.RandomSeed = NormalizeHashCode(randomSeed);
             if (_isFirst || _useRandom != useRandom)
                 _effect.UseRandom = useRandom ? 1.0f : 0.0f;
 


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [x] このPRには1つの機能（または1つの修正）のみが含まれています
- [x] `YukkuriMovieMaker.dll`などYMM4本体の内部実装アセンブリを参照していません

## 概要
<!-- 変更内容を簡単に記載してください -->

GetHashCode()の戻り値をそのままfloatにキャストするとfloatの仮数部23bitの精度限界により下位ビットが消失し、FractalNoiseの出力が定数に近い値に縮退してランダムモードで波形が消える問題がありました。

intをuintに再解釈した上でuint.MaxValueで除算し[0,1)に正規化することで、32bitの情報を損失なく活用しつつシェーダーのHash/FractalNoiseが想定するスケールに一致させました。

あわせてRandomSeedの責務をプロセッサーからエフェクトクラスに移動し、不変値であるため送出をUpdateからCreateEffectに移しました。