### PR TITLE
映像エフェクト「同型塗りつぶし」を追加

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeCustomEffect.cs
@@ -1,0 +1,84 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Commons;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
+{
+    internal sealed class FillSametypeCustomEffect(IGraphicsDevicesAndContext devices)
+        : D2D1CustomShaderEffectBase(Create<EffectImpl>(devices))
+    {
+        public Vector4 TargetColor
+        {
+            set => SetValue((int)EffectImpl.Properties.TargetColor, value);
+            get => GetVector4Value((int)EffectImpl.Properties.TargetColor);
+        }
+
+        public float Tolerance
+        {
+            set => SetValue((int)EffectImpl.Properties.Tolerance, value);
+            get => GetFloatValue((int)EffectImpl.Properties.Tolerance);
+        }
+
+        public float Invert
+        {
+            set => SetValue((int)EffectImpl.Properties.Invert, value);
+            get => GetFloatValue((int)EffectImpl.Properties.Invert);
+        }
+
+        [CustomEffect(1)]
+        class EffectImpl : D2D1CustomShaderEffectImplBase<EffectImpl>
+        {
+            ConstantBuffer constants;
+
+            [CustomEffectProperty(PropertyType.Vector4, (int)Properties.TargetColor)]
+            public Vector4 TargetColor
+            {
+                get => constants.TargetColor;
+                set { constants.TargetColor = value; UpdateConstants(); }
+            }
+
+            [CustomEffectProperty(PropertyType.Float, (int)Properties.Tolerance)]
+            public float Tolerance
+            {
+                get => constants.Tolerance;
+                set { constants.Tolerance = value; UpdateConstants(); }
+            }
+
+            [CustomEffectProperty(PropertyType.Float, (int)Properties.Invert)]
+            public float Invert
+            {
+                get => constants.Invert;
+                set { constants.Invert = value; UpdateConstants(); }
+            }
+
+            public EffectImpl() : base(ShaderResourceUri.Get("FillSamegroundShader"))
+            {
+            }
+
+            protected override void UpdateConstants()
+            {
+                drawInformation?.SetPixelShaderConstantBuffer(constants);
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            struct ConstantBuffer
+            {
+                public Vector4 TargetColor;
+                public float Tolerance;
+                public float Invert;
+                float _pad1;
+                float _pad2;
+            }
+
+            public enum Properties : int
+            {
+                TargetColor = 0,
+                Tolerance = 1,
+                Invert = 2,
+            }
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeEffect.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Effects;
+using YukkuriMovieMaker.Project;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
+{
+    [VideoEffect(nameof(Texts.FillSametypeEffectName), [VideoEffectCategories.Decoration], ["fill", "同型", "塗りつぶし", "形状"], IsAviUtlSupported = false, ResourceType = typeof(Texts))]
+    public class FillSametypeEffect : VideoEffectBase
+    {
+        public override string Label => Texts.FillSametypeEffectName;
+
+        [Display(GroupName = nameof(Texts.FillSametypeEffectName), Name = nameof(Texts.FillSametypeOpacityName), ResourceType = typeof(Texts), Order = 0)]
+        [AnimationSlider("F1", "%", 0, 100)]
+        public Animation Opacity { get; } = new Animation(100, 0, 100);
+
+        [Display(GroupName = nameof(Texts.FillSametypeEffectName), Name = nameof(Texts.FillSametypeBlurName), ResourceType = typeof(Texts), Order = 10)]
+        [AnimationSlider("F1", "px", 0, 10)]
+        public Animation Blur { get; } = new Animation(0, 0, 100000);
+
+        [Display(GroupName = nameof(Texts.FillSametypeEffectName), Name = nameof(Texts.FillSametypeBlendModeName), ResourceType = typeof(Texts), Order = 20)]
+        [EnumComboBox]
+        public Blend BlendMode
+        {
+            get => blendMode;
+            set => Set(ref blendMode, value);
+        }
+        Blend blendMode = Blend.Normal;
+
+        [Display(GroupName = nameof(Texts.FillSametypeEffectName), Name = nameof(Texts.FillSametypeIsInvertedName), ResourceType = typeof(Texts), Order = 30)]
+        [ToggleSlider]
+        public bool IsInverted
+        {
+            get => isInverted;
+            set => Set(ref isInverted, value);
+        }
+        bool isInverted;
+
+        [Display(GroupName = nameof(Texts.FillSametypeEffectName), Name = nameof(Texts.FillSametypeIsBrushOnlyName), ResourceType = typeof(Texts), Order = 40)]
+        [ToggleSlider]
+        public bool IsBrushOnly
+        {
+            get => isBrushOnly;
+            set => Set(ref isBrushOnly, value);
+        }
+        bool isBrushOnly;
+
+        [Display(GroupName = nameof(Texts.FillSametypeEffectName), Name = nameof(Texts.FillSametypePreserveLuminanceName), ResourceType = typeof(Texts), Order = 45)]
+        [ToggleSlider]
+        public bool PreserveLuminance
+        {
+            get => preserveLuminance;
+            set => Set(ref preserveLuminance, value);
+        }
+        bool preserveLuminance;
+
+        [Display(GroupName = nameof(Texts.FillSametypeTargetGroupName), Name = nameof(Texts.FillSametypeXName), ResourceType = typeof(Texts), Order = 110)]
+        [AnimationSlider("F1", "px", -2000, 2000)]
+        public Animation X { get; } = new Animation(0, YMM4Constants.VerySmallValue, YMM4Constants.VeryLargeValue);
+
+        [Display(GroupName = nameof(Texts.FillSametypeTargetGroupName), Name = nameof(Texts.FillSametypeYName), ResourceType = typeof(Texts), Order = 111)]
+        [AnimationSlider("F1", "px", -2000, 2000)]
+        public Animation Y { get; } = new Animation(0, YMM4Constants.VerySmallValue, YMM4Constants.VeryLargeValue);
+
+        [Display(GroupName = nameof(Texts.FillSametypeTargetGroupName), Name = nameof(Texts.FillSametypeToleranceName), ResourceType = typeof(Texts), Order = 130)]
+        [AnimationSlider("F0", "", 0, 255)]
+        public Animation Tolerance { get; } = new Animation(15, 0, 255);
+
+        [Display(GroupName = nameof(Texts.FillSametypeTargetGroupName), Name = nameof(Texts.FillSametypeShapeThresholdName), ResourceType = typeof(Texts), Order = 140)]
+        [AnimationSlider("F2", "", 0, 100)]
+        public Animation ShapeThreshold { get; } = new Animation(20, 0, 100);
+
+        [Display(GroupName = nameof(Texts.FillSametypeBrushGroupName), Order = 200, AutoGenerateField = true, ResourceType = typeof(Texts))]
+        public YukkuriMovieMaker.Plugin.Brush.Brush Brush { get; } = new YukkuriMovieMaker.Plugin.Brush.Brush();
+
+        public override IEnumerable<string> CreateExoVideoFilters(int keyFrameIndex, ExoOutputDescription exoOutputDescription)
+        {
+            return [];
+        }
+
+        public override IVideoEffectProcessor CreateVideoEffect(IGraphicsDevicesAndContext devices)
+        {
+            return new FillSametypeProcessor(devices, this);
+        }
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [Opacity, Blur, X, Y, Tolerance, ShapeThreshold, Brush];
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeGpuShaders.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeGpuShaders.cs
@@ -1,0 +1,217 @@
+using ComputeSharp;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct ClearBufferShader(
+    ReadWriteBuffer<int> buffer,
+    int gridWidth,
+    int length) : IComputeShader
+{
+    private readonly ReadWriteBuffer<int> buffer = buffer;
+    private readonly int gridWidth = gridWidth;
+    private readonly int length = length;
+
+    public void Execute()
+    {
+        int index = ThreadIds.Y * gridWidth + ThreadIds.X;
+        if (index < length)
+            buffer[index] = 0;
+    }
+}
+
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct LogPolarHistogramShader(
+    ReadOnlyBuffer<int> labels,
+    ReadOnlyBuffer<float> centroids,
+    ReadWriteBuffer<int> histogram,
+    int angleBins,
+    int radialBins,
+    float logRadiusScale,
+    int width,
+    int height) : IComputeShader
+{
+    private readonly ReadOnlyBuffer<int> labels = labels;
+    private readonly ReadOnlyBuffer<float> centroids = centroids;
+    private readonly ReadWriteBuffer<int> histogram = histogram;
+    private readonly int angleBins = angleBins;
+    private readonly int radialBins = radialBins;
+    private readonly float logRadiusScale = logRadiusScale;
+    private readonly int width = width;
+    private readonly int height = height;
+
+    public void Execute()
+    {
+        int x = ThreadIds.X;
+        int y = ThreadIds.Y;
+        if (x < width && y < height)
+        {
+            int index = y * width + x;
+            int label = labels[index];
+            if (label >= 0)
+            {
+                float cx = centroids[label * 2 + 0];
+                float cy = centroids[label * 2 + 1];
+
+                float dx = x - cx;
+                float dy = y - cy;
+                float radius = Hlsl.Sqrt(dx * dx + dy * dy);
+
+                if (radius >= 1.0f)
+                {
+                    float angle = Hlsl.Atan2(dy, dx);
+                    float twoPi = 6.28318530718f;
+                    float normalizedAngle = (angle + 3.14159265359f) / twoPi;
+
+                    int angleBin = (int)(normalizedAngle * angleBins);
+                    if (angleBin >= angleBins)
+                        angleBin = angleBins - 1;
+                    if (angleBin < 0)
+                        angleBin = 0;
+
+                    int radiusBin = (int)(Hlsl.Log(radius) * logRadiusScale);
+                    if (radiusBin >= radialBins)
+                        radiusBin = radialBins - 1;
+                    if (radiusBin < 0)
+                        radiusBin = 0;
+
+                    int featureSize = angleBins * radialBins;
+                    int slot = label * featureSize + angleBin * radialBins + radiusBin;
+                    Hlsl.InterlockedAdd(ref histogram[slot], 1);
+                }
+            }
+        }
+    }
+}
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct NormalizeHistogramShader(
+    ReadWriteBuffer<int> histogram,
+    ReadWriteBuffer<float> features,
+    int featureSize,
+    int componentCount) : IComputeShader
+{
+    private readonly ReadWriteBuffer<int> histogram = histogram;
+    private readonly ReadWriteBuffer<float> features = features;
+    private readonly int featureSize = featureSize;
+    private readonly int componentCount = componentCount;
+
+    public void Execute()
+    {
+        int component = ThreadIds.X;
+        if (component < componentCount)
+        {
+            int baseIndex = component * featureSize;
+
+            float sumSq = 0f;
+            for (int k = 0; k < featureSize; k++)
+            {
+                float v = (float)histogram[baseIndex + k];
+                sumSq = sumSq + v * v;
+            }
+
+            float norm = Hlsl.Sqrt(sumSq);
+            float invNorm = norm > 1e-6f ? 1.0f / norm : 0f;
+
+            for (int k = 0; k < featureSize; k++)
+                features[baseIndex + k] = (float)histogram[baseIndex + k] * invNorm;
+        }
+    }
+}
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct CorrelationMatchShader(
+    ReadWriteBuffer<float> features,
+    ReadWriteBuffer<int> matchFlags,
+    int seedComponent,
+    int angleBins,
+    int radialBins,
+    float threshold,
+    int componentCount) : IComputeShader
+{
+    private readonly ReadWriteBuffer<float> features = features;
+    private readonly ReadWriteBuffer<int> matchFlags = matchFlags;
+    private readonly int seedComponent = seedComponent;
+    private readonly int angleBins = angleBins;
+    private readonly int radialBins = radialBins;
+    private readonly float threshold = threshold;
+    private readonly int componentCount = componentCount;
+
+    public void Execute()
+    {
+        int component = ThreadIds.X;
+        if (component < componentCount)
+        {
+            int featureSize = angleBins * radialBins;
+            int seedBase = seedComponent * featureSize;
+            int candBase = component * featureSize;
+
+            float best = 0f;
+
+            for (int shift = 0; shift < angleBins; shift++)
+            {
+                float dot = 0f;
+
+                for (int a = 0; a < angleBins; a++)
+                {
+                    int rotated = a + shift;
+                    if (rotated >= angleBins)
+                        rotated = rotated - angleBins;
+
+                    int seedRow = seedBase + a * radialBins;
+                    int candRow = candBase + rotated * radialBins;
+
+                    for (int r = 0; r < radialBins; r++)
+                        dot = dot + features[seedRow + r] * features[candRow + r];
+                }
+
+                if (dot > best)
+                    best = dot;
+            }
+
+            matchFlags[component] = best >= threshold ? 1 : 0;
+        }
+    }
+}
+
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct MaskShader(
+    ReadOnlyBuffer<int> labels,
+    ReadWriteBuffer<int> matchFlags,
+    ReadWriteBuffer<int> mask,
+    int invert,
+    int width,
+    int height) : IComputeShader
+{
+    private readonly ReadOnlyBuffer<int> labels = labels;
+    private readonly ReadWriteBuffer<int> matchFlags = matchFlags;
+    private readonly ReadWriteBuffer<int> mask = mask;
+    private readonly int invert = invert;
+    private readonly int width = width;
+    private readonly int height = height;
+
+    public void Execute()
+    {
+        int x = ThreadIds.X;
+        int y = ThreadIds.Y;
+        if (x < width && y < height)
+        {
+            int index = y * width + x;
+            int label = labels[index];
+
+            int matched = 0;
+            if (label >= 0 && matchFlags[label] != 0)
+                matched = 1;
+
+            if (invert != 0)
+                matched = 1 - matched;
+
+            mask[index] = matched != 0 ? -1 : 0;
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypePipeline.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypePipeline.cs
@@ -32,6 +32,7 @@ internal sealed class FillSametypePipeline : IDisposable
 
     int[] labels = [];
     int[] parent = [];
+    int[] rank = [];
     int[] remap = [];
     double[] moments = [];
     float[] centroids = [];
@@ -133,7 +134,10 @@ internal sealed class FillSametypePipeline : IDisposable
         Array.Fill(remap, -1, 0, pixelCount);
 
         for (int i = 0; i < pixelCount; i++)
+        {
             parent[i] = i;
+            rank[i] = 0;
+        }
 
         for (int y = 0; y < height; y++)
         {
@@ -186,10 +190,15 @@ internal sealed class FillSametypePipeline : IDisposable
         int rb = Find(b);
         if (ra == rb)
             return;
-        if (ra < rb)
+        if (rank[ra] < rank[rb])
+            parent[ra] = rb;
+        else if (rank[ra] > rank[rb])
             parent[rb] = ra;
         else
-            parent[ra] = rb;
+        {
+            parent[rb] = ra;
+            rank[ra]++;
+        }
     }
 
     int Find(int x)
@@ -255,6 +264,7 @@ internal sealed class FillSametypePipeline : IDisposable
 
         labels = new int[pixelCount];
         parent = new int[pixelCount];
+        rank = new int[pixelCount];
         remap = new int[pixelCount];
     }
 

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypePipeline.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypePipeline.cs
@@ -106,20 +106,25 @@ internal sealed class FillSametypePipeline : IDisposable
 
         float similarityThreshold = 1f - Math.Clamp(threshold / 100f, 0f, 1f);
 
-        bool matchChanged = seedComponent != lastSeedComponent
+        bool correlationChanged = seedComponent != lastSeedComponent
             || similarityThreshold != lastSimilarityThreshold
-            || analysisGeneration != lastMatchGeneration
-            || invert != lastInvert;
+            || analysisGeneration != lastMatchGeneration;
 
-        if (!matchChanged)
+        bool maskChanged = correlationChanged || invert != lastInvert;
+
+        if (!maskChanged)
             return false;
 
-        device.For(componentCount, new CorrelationMatchShader(
-            featureBuffer, matchFlagBuffer, seedComponent, AngleBins, RadialBins, similarityThreshold, componentCount));
+        if (correlationChanged)
+        {
+            device.For(componentCount, new CorrelationMatchShader(
+                featureBuffer, matchFlagBuffer, seedComponent, AngleBins, RadialBins, similarityThreshold, componentCount));
 
-        lastSeedComponent = seedComponent;
-        lastSimilarityThreshold = similarityThreshold;
-        lastMatchGeneration = analysisGeneration;
+            lastSeedComponent = seedComponent;
+            lastSimilarityThreshold = similarityThreshold;
+            lastMatchGeneration = analysisGeneration;
+        }
+
         lastInvert = invert;
 
         device.For(width, height, new MaskShader(

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypePipeline.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypePipeline.cs
@@ -35,6 +35,7 @@ internal sealed class FillSametypePipeline : IDisposable
     int[] remap = [];
     double[] moments = [];
     float[] centroids = [];
+    int momentCapacity;
 
     public FillSametypePipeline()
     {
@@ -54,6 +55,7 @@ internal sealed class FillSametypePipeline : IDisposable
         if (componentCount == 0)
             return 0;
 
+        EnsureMomentCapacity(componentCount);
         ComputeCentroids(width, height, componentCount);
 
         var labelGpu = EnsureLabelBuffer(pixelCount);
@@ -232,6 +234,16 @@ internal sealed class FillSametypePipeline : IDisposable
         }
     }
 
+    void EnsureMomentCapacity(int count)
+    {
+        if (momentCapacity >= count)
+            return;
+
+        moments = new double[count * MomentStride];
+        centroids = new float[count * 2];
+        momentCapacity = count;
+    }
+
     void EnsureCapacity(int width, int height)
     {
         if (this.width == width && this.height == height && labels.Length >= width * height)
@@ -244,8 +256,6 @@ internal sealed class FillSametypePipeline : IDisposable
         labels = new int[pixelCount];
         parent = new int[pixelCount];
         remap = new int[pixelCount];
-        moments = new double[MaximumComponents * MomentStride];
-        centroids = new float[MaximumComponents * 2];
     }
 
     ReadOnlyBuffer<int> EnsureLabelBuffer(int count)

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypePipeline.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypePipeline.cs
@@ -1,0 +1,334 @@
+using ComputeSharp;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype;
+
+internal sealed class FillSametypePipeline : IDisposable
+{
+    readonly GraphicsDevice device;
+
+    ReadOnlyBuffer<int>? labelBuffer;
+    ReadOnlyBuffer<float>? centroidBuffer;
+    ReadWriteBuffer<int>? histogramBuffer;
+    ReadWriteBuffer<float>? featureBuffer;
+    ReadWriteBuffer<int>? matchFlagBuffer;
+    ReadWriteBuffer<int>? maskBuffer;
+
+    int width;
+    int height;
+    int pixelCount;
+    int componentCount;
+    int analysisGeneration;
+    int lastSeedComponent = -1;
+    float lastSimilarityThreshold = float.NaN;
+    int lastMatchGeneration = -1;
+    bool lastInvert;
+
+    const int MinimumComponentArea = 16;
+    const int MomentStride = 3;
+    const int AngleBins = 36;
+    const int RadialBins = 12;
+    const int FeatureSize = AngleBins * RadialBins;
+    const int MaximumComponents = 65536;
+
+    int[] labels = [];
+    int[] parent = [];
+    int[] remap = [];
+    double[] moments = [];
+    float[] centroids = [];
+
+    public FillSametypePipeline()
+    {
+        device = GraphicsDevice.GetDefault();
+    }
+
+    public bool IsForeground(int index)
+    {
+        return (uint)index < (uint)pixelCount && labels[index] >= 0;
+    }
+
+    public int Analyze(ReadOnlySpan<int> foreground, int width, int height)
+    {
+        EnsureCapacity(width, height);
+
+        componentCount = Label(foreground, width, height);
+        if (componentCount == 0)
+            return 0;
+
+        ComputeCentroids(width, height, componentCount);
+
+        var labelGpu = EnsureLabelBuffer(pixelCount);
+        var centroidGpu = EnsureCentroidBuffer(componentCount);
+        var histogramGpu = EnsureHistogramBuffer(componentCount);
+        var featureGpu = EnsureFeatureBuffer(componentCount);
+        EnsureMatchFlagBuffer(componentCount);
+        EnsureMaskBuffer(pixelCount);
+
+        labelGpu.CopyFrom(labels.AsSpan(0, pixelCount));
+        centroidGpu.CopyFrom(centroids.AsSpan(0, componentCount * 2));
+
+        int histogramLength = componentCount * FeatureSize;
+        device.For(width, CeilDiv(histogramLength, width), new ClearBufferShader(histogramGpu, width, histogramLength));
+
+        float maxRadius = (float)Math.Sqrt((double)width * width + (double)height * height);
+        float logRadiusScale = RadialBins / (float)Math.Log(maxRadius);
+
+        device.For(width, height, new LogPolarHistogramShader(
+            labelGpu, centroidGpu, histogramGpu, AngleBins, RadialBins, logRadiusScale, width, height));
+
+        device.For(componentCount, new NormalizeHistogramShader(histogramGpu, featureGpu, FeatureSize, componentCount));
+
+        analysisGeneration++;
+
+        return componentCount;
+    }
+
+    public bool GenerateMask(int seedIndex, float threshold, bool invert, Span<int> maskResult)
+    {
+        if (componentCount == 0
+            || labelBuffer is null
+            || featureBuffer is null
+            || matchFlagBuffer is null
+            || maskBuffer is null)
+        {
+            maskResult.Clear();
+            return true;
+        }
+
+        int seedComponent = labels[seedIndex];
+        if (seedComponent < 0 || moments[seedComponent * MomentStride] < MinimumComponentArea)
+        {
+            maskResult.Clear();
+            return true;
+        }
+
+        float similarityThreshold = 1f - Math.Clamp(threshold / 100f, 0f, 1f);
+
+        bool matchChanged = seedComponent != lastSeedComponent
+            || similarityThreshold != lastSimilarityThreshold
+            || analysisGeneration != lastMatchGeneration
+            || invert != lastInvert;
+
+        if (!matchChanged)
+            return false;
+
+        device.For(componentCount, new CorrelationMatchShader(
+            featureBuffer, matchFlagBuffer, seedComponent, AngleBins, RadialBins, similarityThreshold, componentCount));
+
+        lastSeedComponent = seedComponent;
+        lastSimilarityThreshold = similarityThreshold;
+        lastMatchGeneration = analysisGeneration;
+        lastInvert = invert;
+
+        device.For(width, height, new MaskShader(
+            labelBuffer, matchFlagBuffer, maskBuffer, invert ? 1 : 0, width, height));
+
+        maskBuffer.CopyTo(maskResult);
+        return true;
+    }
+
+    int Label(ReadOnlySpan<int> foreground, int width, int height)
+    {
+        Array.Fill(remap, -1, 0, pixelCount);
+
+        for (int i = 0; i < pixelCount; i++)
+            parent[i] = i;
+
+        for (int y = 0; y < height; y++)
+        {
+            int rowBase = y * width;
+            for (int x = 0; x < width; x++)
+            {
+                int index = rowBase + x;
+                if (foreground[index] == 0)
+                    continue;
+
+                if (x > 0 && foreground[index - 1] != 0)
+                    Union(index, index - 1);
+                if (y > 0 && foreground[index - width] != 0)
+                    Union(index, index - width);
+                if (y > 0 && x > 0 && foreground[index - width - 1] != 0)
+                    Union(index, index - width - 1);
+                if (y > 0 && x < width - 1 && foreground[index - width + 1] != 0)
+                    Union(index, index - width + 1);
+            }
+        }
+
+        int count = 0;
+        for (int i = 0; i < pixelCount; i++)
+        {
+            if (foreground[i] == 0)
+            {
+                labels[i] = -1;
+                continue;
+            }
+
+            int root = Find(i);
+            if (remap[root] < 0)
+            {
+                if (count >= MaximumComponents)
+                {
+                    labels[i] = -1;
+                    continue;
+                }
+                remap[root] = count++;
+            }
+            labels[i] = remap[root];
+        }
+
+        return count;
+    }
+
+    void Union(int a, int b)
+    {
+        int ra = Find(a);
+        int rb = Find(b);
+        if (ra == rb)
+            return;
+        if (ra < rb)
+            parent[rb] = ra;
+        else
+            parent[ra] = rb;
+    }
+
+    int Find(int x)
+    {
+        while (parent[x] != x)
+        {
+            parent[x] = parent[parent[x]];
+            x = parent[x];
+        }
+        return x;
+    }
+
+    void ComputeCentroids(int width, int height, int componentCount)
+    {
+        Array.Clear(moments, 0, componentCount * MomentStride);
+
+        var moment = moments;
+        var label = labels;
+
+        for (int y = 0; y < height; y++)
+        {
+            int rowBase = y * width;
+            for (int x = 0; x < width; x++)
+            {
+                int c = label[rowBase + x];
+                if (c < 0)
+                    continue;
+
+                int b = c * MomentStride;
+                moment[b + 0] += 1;
+                moment[b + 1] += x;
+                moment[b + 2] += y;
+            }
+        }
+
+        for (int c = 0; c < componentCount; c++)
+        {
+            int b = c * MomentStride;
+            double m00 = moment[b + 0];
+            centroids[c * 2 + 0] = (float)(moment[b + 1] / m00);
+            centroids[c * 2 + 1] = (float)(moment[b + 2] / m00);
+        }
+    }
+
+    void EnsureCapacity(int width, int height)
+    {
+        if (this.width == width && this.height == height && labels.Length >= width * height)
+            return;
+
+        this.width = width;
+        this.height = height;
+        pixelCount = width * height;
+
+        labels = new int[pixelCount];
+        parent = new int[pixelCount];
+        remap = new int[pixelCount];
+        moments = new double[MaximumComponents * MomentStride];
+        centroids = new float[MaximumComponents * 2];
+    }
+
+    ReadOnlyBuffer<int> EnsureLabelBuffer(int count)
+    {
+        if (labelBuffer is null || labelBuffer.Length < count)
+        {
+            labelBuffer?.Dispose();
+            labelBuffer = device.AllocateReadOnlyBuffer<int>(count);
+        }
+        return labelBuffer;
+    }
+
+    ReadOnlyBuffer<float> EnsureCentroidBuffer(int componentCount)
+    {
+        int count = componentCount * 2;
+        if (centroidBuffer is null || centroidBuffer.Length < count)
+        {
+            centroidBuffer?.Dispose();
+            centroidBuffer = device.AllocateReadOnlyBuffer<float>(count);
+        }
+        return centroidBuffer;
+    }
+
+    ReadWriteBuffer<int> EnsureHistogramBuffer(int componentCount)
+    {
+        int count = componentCount * FeatureSize;
+        if (histogramBuffer is null || histogramBuffer.Length < count)
+        {
+            histogramBuffer?.Dispose();
+            histogramBuffer = device.AllocateReadWriteBuffer<int>(count);
+        }
+        return histogramBuffer;
+    }
+
+    ReadWriteBuffer<float> EnsureFeatureBuffer(int componentCount)
+    {
+        int count = componentCount * FeatureSize;
+        if (featureBuffer is null || featureBuffer.Length < count)
+        {
+            featureBuffer?.Dispose();
+            featureBuffer = device.AllocateReadWriteBuffer<float>(count);
+        }
+        return featureBuffer;
+    }
+
+    ReadWriteBuffer<int> EnsureMatchFlagBuffer(int count)
+    {
+        if (matchFlagBuffer is null || matchFlagBuffer.Length < count)
+        {
+            matchFlagBuffer?.Dispose();
+            matchFlagBuffer = device.AllocateReadWriteBuffer<int>(count);
+        }
+        return matchFlagBuffer;
+    }
+
+    ReadWriteBuffer<int> EnsureMaskBuffer(int count)
+    {
+        if (maskBuffer is null || maskBuffer.Length < count)
+        {
+            maskBuffer?.Dispose();
+            maskBuffer = device.AllocateReadWriteBuffer<int>(count);
+        }
+        return maskBuffer;
+    }
+
+    static int CeilDiv(int value, int divisor)
+    {
+        return (value + divisor - 1) / divisor;
+    }
+
+    public void Dispose()
+    {
+        labelBuffer?.Dispose();
+        centroidBuffer?.Dispose();
+        histogramBuffer?.Dispose();
+        featureBuffer?.Dispose();
+        matchFlagBuffer?.Dispose();
+        maskBuffer?.Dispose();
+        labelBuffer = null;
+        centroidBuffer = null;
+        histogramBuffer = null;
+        featureBuffer = null;
+        matchFlagBuffer = null;
+        maskBuffer = null;
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypePipeline.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypePipeline.cs
@@ -48,6 +48,14 @@ internal sealed class FillSametypePipeline : IDisposable
         return (uint)index < (uint)pixelCount && labels[index] >= 0;
     }
 
+    public void InvalidateMatchCache()
+    {
+        lastSeedComponent = -1;
+        lastSimilarityThreshold = float.NaN;
+        lastMatchGeneration = -1;
+        lastInvert = false;
+    }
+
     public int Analyze(ReadOnlySpan<int> foreground, int width, int height)
     {
         EnsureCapacity(width, height);

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
@@ -174,15 +174,13 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
             var currentY = item.Y.GetValue(frame, length, fps);
             var currentBrushType = item.Brush.Type;
 
-            bool brushUpdated = false;
             if (isFirst || brushType != currentBrushType)
             {
                 disposer.RemoveAndDispose(ref brushSource);
                 brushSource = item.Brush.CreateBrush(devices);
                 disposer.Collect(brushSource);
-                brushUpdated = true;
             }
-            brushUpdated |= brushSource?.Update(effectDescription) ?? false;
+            brushSource?.Update(effectDescription);
 
             bool needsMaskUpdate = isFirst
                 || currentInput != input
@@ -574,14 +572,14 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
 
         (int[] Foreground, int[] Mask) EnsureBuffers(int pixelCount)
         {
-            if (bufferPixelCount < pixelCount || foregroundBuffer is null || maskBuffer is null)
+            if (bufferPixelCount < pixelCount)
             {
                 foregroundBuffer = new int[pixelCount];
                 maskBuffer = new int[pixelCount];
                 bufferPixelCount = pixelCount;
             }
 
-            return (foregroundBuffer, maskBuffer);
+            return (foregroundBuffer!, maskBuffer!);
         }
     }
 }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
@@ -31,6 +31,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
         ID2D1Image? colorMatchOutput;
         GaussianBlur? blurEffect;
         Vortice.Direct2D1.Effects.AlphaMask? alphaMaskEffect;
+        ID2D1Image? alphaMaskOutput;
         Vortice.Direct2D1.Effects.AlphaMask? luminanceMaskEffect;
         Opacity? opacityEffect;
         AffineTransform2D? finalMaskTransform;
@@ -53,7 +54,6 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
         int bufferPixelCount;
 
         bool isFirst = true;
-        ID2D1Image? currentInput;
         Type? brushType;
         RawRectF lastBounds;
         double opacity, blur, tolerance, shapeThreshold, posX, posY;
@@ -61,6 +61,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
         Vector4 lastMatchColor;
         double lastForegroundTolerance;
         int lastComponentCount;
+        int lastAnalyzedFrame = -1;
 
         public FillSametypeProcessor(IGraphicsDevicesAndContext devices, FillSametypeEffect item)
             : base(devices)
@@ -95,6 +96,9 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
             alphaMaskEffect = new Vortice.Direct2D1.Effects.AlphaMask(devices.DeviceContext);
             disposer.Collect(alphaMaskEffect);
 
+            alphaMaskOutput = alphaMaskEffect.Output;
+            disposer.Collect(alphaMaskOutput);
+
             luminanceMaskEffect = new Vortice.Direct2D1.Effects.AlphaMask(devices.DeviceContext);
             disposer.Collect(luminanceMaskEffect);
 
@@ -110,7 +114,6 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
             finalMaskTransformOutput = finalMaskTransform.Output;
             disposer.Collect(finalMaskTransformOutput);
 
-            using var alphaMaskOutput = alphaMaskEffect.Output;
             opacityEffect.SetInput(0, alphaMaskOutput, true);
         }
 
@@ -134,7 +137,6 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
             outputEffect?.SetInput(0, null, true);
             alphaMaskEffect?.SetInput(0, null, true);
             alphaMaskEffect?.SetInput(1, null, true);
-            opacityEffect?.SetInput(0, null, true);
             luminanceMaskEffect?.SetInput(0, null, true);
             luminanceMaskEffect?.SetInput(1, null, true);
             blurEffect?.SetInput(0, null, true);
@@ -184,18 +186,18 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
             brushSource?.Update(effectDescription);
 
             bool needsMaskUpdate = isFirst
-                || currentInput != input
                 || !lastBounds.Equals(bounds)
                 || tolerance != currentTolerance
                 || shapeThreshold != currentShapeThreshold
                 || isInverted != currentIsInverted
                 || posX != currentX
-                || posY != currentY;
+                || posY != currentY
+                || frame != lastAnalyzedFrame;
 
             ID2D1Image? maskSource;
             if (needsMaskUpdate)
             {
-                maskSource = PrepareSametypeMask(dc, bounds, width, height, currentX, currentY, currentTolerance, currentShapeThreshold, currentIsInverted);
+                maskSource = PrepareSametypeMask(dc, bounds, width, height, currentX, currentY, currentTolerance, currentShapeThreshold, currentIsInverted, frame);
             }
             else
             {
@@ -282,7 +284,6 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
             }
 
             isFirst = false;
-            currentInput = input;
             lastBounds = bounds;
             opacity = currentOpacity;
             blur = currentBlur;
@@ -324,7 +325,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
             double y,
             double toleranceRaw,
             double shapeThresholdRaw,
-            bool invert)
+            bool invert,
+            int frame)
         {
             int pixelCount = width * height;
             var mask = EnsureBuffers(pixelCount).Mask;
@@ -332,10 +334,10 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
             Vector4 matchColor = ReadSeedColor(dc, bounds, width, height, x, y, out int seedX, out int seedY);
 
             bool foregroundChanged = isFirst
+                || frame != lastAnalyzedFrame
                 || toleranceRaw != lastForegroundTolerance
                 || !ColorWithinTolerance(matchColor, lastMatchColor, toleranceRaw)
-                || !lastBounds.Equals(bounds)
-                || currentInput != input;
+                || !lastBounds.Equals(bounds);
 
             int components;
             if (foregroundChanged)
@@ -346,6 +348,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
                 lastMatchColor = matchColor;
                 lastForegroundTolerance = toleranceRaw;
                 lastComponentCount = components;
+                lastAnalyzedFrame = frame;
             }
             else
             {

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
@@ -361,6 +361,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
                 Array.Clear(mask, 0, pixelCount);
                 EnsureFinalMaskBitmap(dc, width, height);
                 finalMaskBitmap!.CopyFromMemory<int>(mask, width * 4);
+                pipeline.InvalidateMatchCache();
                 return TransformFinalMask(bounds);
             }
 

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
@@ -1,0 +1,586 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+using Vortice;
+using Vortice.Direct2D1;
+using Vortice.Direct2D1.Effects;
+using Vortice.DCommon;
+using Vortice.DXGI;
+using Vortice.Mathematics;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Player.Video.Effects;
+using YukkuriMovieMaker.Plugin.Brush;
+using YukkuriMovieMaker.Player;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
+{
+    public class FillSametypeProcessor : VideoEffectProcessorBase
+    {
+        readonly IGraphicsDevicesAndContext devices;
+        readonly FillSametypeEffect item;
+
+        AffineTransform2D? outputEffect;
+        ID2D1CommandList? brushCommandList;
+        ID2D1CommandList? blendedCommandList;
+        ID2D1CommandList? luminanceCommandList;
+
+        IBrushSource? brushSource;
+        readonly ID2D1SolidColorBrush transparentBrush;
+
+        FillSametypeCustomEffect? colorMatchEffect;
+        ID2D1Image? colorMatchOutput;
+        GaussianBlur? blurEffect;
+        Vortice.Direct2D1.Effects.AlphaMask? alphaMaskEffect;
+        Vortice.Direct2D1.Effects.AlphaMask? luminanceMaskEffect;
+        Opacity? opacityEffect;
+        AffineTransform2D? finalMaskTransform;
+        ID2D1Image? finalMaskTransformOutput;
+
+        ID2D1Bitmap1? finalMaskBitmap;
+        int finalMaskWidth, finalMaskHeight;
+
+        ID2D1Bitmap1? candidateBitmap;
+        ID2D1Bitmap1? candidateStagingBitmap;
+        int candidateWidth, candidateHeight;
+
+        ID2D1Bitmap1? seedBitmap;
+        ID2D1Bitmap1? seedStagingBitmap;
+        readonly byte[] seedPixel = new byte[4];
+
+        readonly FillSametypePipeline pipeline = new();
+        int[]? foregroundBuffer;
+        int[]? maskBuffer;
+        int bufferPixelCount;
+
+        bool isFirst = true;
+        ID2D1Image? currentInput;
+        Type? brushType;
+        RawRectF lastBounds;
+        double opacity, blur, tolerance, shapeThreshold, posX, posY;
+        bool isInverted;
+        Vector4 lastMatchColor;
+        double lastForegroundTolerance;
+        int lastComponentCount;
+
+        public FillSametypeProcessor(IGraphicsDevicesAndContext devices, FillSametypeEffect item)
+            : base(devices)
+        {
+            this.devices = devices;
+            this.item = item;
+
+            transparentBrush = devices.DeviceContext.CreateSolidColorBrush(new Color4(0f, 0f, 0f, 0f));
+            disposer.Collect(transparentBrush);
+            disposer.Collect(pipeline);
+
+            colorMatchEffect = new FillSametypeCustomEffect(devices);
+            if (!colorMatchEffect.IsEnabled)
+            {
+                colorMatchEffect.Dispose();
+                colorMatchEffect = null;
+            }
+            else
+            {
+                colorMatchOutput = colorMatchEffect.Output;
+                disposer.Collect(colorMatchEffect);
+                disposer.Collect(colorMatchOutput);
+            }
+
+            blurEffect = new GaussianBlur(devices.DeviceContext)
+            {
+                BorderMode = BorderMode.Hard,
+                Optimization = GaussianBlurOptimization.Balanced,
+            };
+            disposer.Collect(blurEffect);
+
+            alphaMaskEffect = new Vortice.Direct2D1.Effects.AlphaMask(devices.DeviceContext);
+            disposer.Collect(alphaMaskEffect);
+
+            luminanceMaskEffect = new Vortice.Direct2D1.Effects.AlphaMask(devices.DeviceContext);
+            disposer.Collect(luminanceMaskEffect);
+
+            opacityEffect = new Opacity(devices.DeviceContext);
+            disposer.Collect(opacityEffect);
+
+            finalMaskTransform = new AffineTransform2D(devices.DeviceContext)
+            {
+                BorderMode = BorderMode.Hard,
+            };
+            disposer.Collect(finalMaskTransform);
+
+            finalMaskTransformOutput = finalMaskTransform.Output;
+            disposer.Collect(finalMaskTransformOutput);
+
+            using var alphaMaskOutput = alphaMaskEffect.Output;
+            opacityEffect.SetInput(0, alphaMaskOutput, true);
+        }
+
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            outputEffect = new AffineTransform2D(devices.DeviceContext);
+            disposer.Collect(outputEffect);
+
+            var output = outputEffect.Output;
+            disposer.Collect(output);
+            return output;
+        }
+
+        protected override void setInput(ID2D1Image? input)
+        {
+        }
+
+        protected override void ClearEffectChain()
+        {
+            colorMatchEffect?.SetInput(0, null, true);
+            outputEffect?.SetInput(0, null, true);
+            alphaMaskEffect?.SetInput(0, null, true);
+            alphaMaskEffect?.SetInput(1, null, true);
+            luminanceMaskEffect?.SetInput(0, null, true);
+            luminanceMaskEffect?.SetInput(1, null, true);
+            blurEffect?.SetInput(0, null, true);
+            finalMaskTransform?.SetInput(0, null, true);
+        }
+
+        public override DrawDescription Update(EffectDescription effectDescription)
+        {
+            if (IsPassThroughEffect || outputEffect is null || input is null)
+                return effectDescription.DrawDescription;
+
+            if (colorMatchEffect is null || colorMatchOutput is null || alphaMaskEffect is null || opacityEffect is null)
+            {
+                outputEffect.SetInput(0, input, true);
+                return effectDescription.DrawDescription;
+            }
+
+            var frame = effectDescription.ItemPosition.Frame;
+            var length = effectDescription.ItemDuration.Frame;
+            var fps = effectDescription.FPS;
+            var dc = devices.DeviceContext;
+            var bounds = dc.GetImageLocalBounds(input);
+            int width = (int)Math.Ceiling(bounds.Right - bounds.Left);
+            int height = (int)Math.Ceiling(bounds.Bottom - bounds.Top);
+
+            if (width <= 0 || height <= 0)
+                return effectDescription.DrawDescription;
+
+            var currentOpacity = item.Opacity.GetValue(frame, length, fps);
+            var currentBlur = Math.Max(0, item.Blur.GetValue(frame, length, fps));
+            var currentBlendMode = item.BlendMode;
+            var currentIsInverted = item.IsInverted;
+            var currentIsBrushOnly = item.IsBrushOnly;
+            var currentPreserveLuminance = item.PreserveLuminance;
+            var currentTolerance = item.Tolerance.GetValue(frame, length, fps);
+            var currentShapeThreshold = item.ShapeThreshold.GetValue(frame, length, fps);
+            var currentX = item.X.GetValue(frame, length, fps);
+            var currentY = item.Y.GetValue(frame, length, fps);
+            var currentBrushType = item.Brush.Type;
+
+            bool brushUpdated = false;
+            if (isFirst || brushType != currentBrushType)
+            {
+                disposer.RemoveAndDispose(ref brushSource);
+                brushSource = item.Brush.CreateBrush(devices);
+                disposer.Collect(brushSource);
+                brushUpdated = true;
+            }
+            brushUpdated |= brushSource?.Update(effectDescription) ?? false;
+
+            bool needsMaskUpdate = isFirst
+                || currentInput != input
+                || !lastBounds.Equals(bounds)
+                || tolerance != currentTolerance
+                || shapeThreshold != currentShapeThreshold
+                || isInverted != currentIsInverted
+                || posX != currentX
+                || posY != currentY;
+
+            ID2D1Image? maskSource;
+            if (needsMaskUpdate)
+            {
+                maskSource = PrepareSametypeMask(dc, bounds, width, height, currentX, currentY, currentTolerance, currentShapeThreshold, currentIsInverted);
+            }
+            else
+            {
+                maskSource = finalMaskTransformOutput;
+            }
+
+            if (maskSource is null)
+            {
+                outputEffect.SetInput(0, input, true);
+                return effectDescription.DrawDescription;
+            }
+
+            if (isFirst || currentBlur != blur)
+                UpdateAlphaMask(maskSource, currentBlur);
+            if (isFirst || currentOpacity != opacity)
+                opacityEffect.Value = (float)(Math.Clamp(currentOpacity, 0, 100) / 100.0);
+
+            disposer.RemoveAndDispose(ref brushCommandList);
+            brushCommandList = dc.CreateCommandList();
+            disposer.Collect(brushCommandList);
+
+            dc.Target = brushCommandList;
+            dc.BeginDraw();
+            dc.Clear(null);
+            dc.FillRectangle(bounds, brushSource?.Brush ?? transparentBrush);
+            dc.EndDraw();
+            dc.Target = null;
+            brushCommandList.Close();
+            alphaMaskEffect.SetInput(0, brushCommandList, true);
+
+            disposer.RemoveAndDispose(ref blendedCommandList);
+            blendedCommandList = dc.CreateCommandList();
+            disposer.Collect(blendedCommandList);
+
+            dc.Target = blendedCommandList;
+            dc.BeginDraw();
+            dc.Clear(null);
+            if (!currentIsBrushOnly)
+                dc.DrawImage(input, InterpolationMode.MultiSampleLinear, CompositeMode.SourceOver);
+
+            using (var opacityOutput = opacityEffect.Output)
+            {
+                if (currentBlendMode.IsCompositionEffect())
+                    dc.DrawImage(opacityOutput, InterpolationMode.MultiSampleLinear, currentBlendMode.ToD2DCompositionMode());
+                else
+                    dc.BlendImage(opacityOutput, currentBlendMode.ToD2DBlendMode(), null, null, effectDescription.DrawDescription.ZoomInterpolationMode);
+            }
+            dc.EndDraw();
+            dc.Target = null;
+            blendedCommandList.Close();
+
+            if (currentPreserveLuminance)
+            {
+                disposer.RemoveAndDispose(ref luminanceCommandList);
+                luminanceCommandList = dc.CreateCommandList();
+                disposer.Collect(luminanceCommandList);
+
+                dc.Target = luminanceCommandList;
+                dc.BeginDraw();
+                dc.Clear(null);
+                dc.DrawImage(blendedCommandList, InterpolationMode.MultiSampleLinear, CompositeMode.SourceOver);
+
+                if (currentIsBrushOnly && luminanceMaskEffect is not null)
+                {
+                    luminanceMaskEffect.SetInput(0, input, true);
+                    luminanceMaskEffect.SetInput(1, blendedCommandList, true);
+                    using var luminanceSource = luminanceMaskEffect.Output;
+                    dc.BlendImage(luminanceSource, Vortice.Direct2D1.BlendMode.Luminosity, null, null, effectDescription.DrawDescription.ZoomInterpolationMode);
+                }
+                else
+                {
+                    dc.BlendImage(input, Vortice.Direct2D1.BlendMode.Luminosity, null, null, effectDescription.DrawDescription.ZoomInterpolationMode);
+                }
+                dc.EndDraw();
+                dc.Target = null;
+                luminanceCommandList.Close();
+
+                outputEffect.SetInput(0, luminanceCommandList, true);
+            }
+            else
+            {
+                outputEffect.SetInput(0, blendedCommandList, true);
+            }
+
+            isFirst = false;
+            currentInput = input;
+            lastBounds = bounds;
+            opacity = currentOpacity;
+            blur = currentBlur;
+            isInverted = currentIsInverted;
+            tolerance = currentTolerance;
+            shapeThreshold = currentShapeThreshold;
+            posX = currentX;
+            posY = currentY;
+            brushType = currentBrushType;
+
+            var controller = new VideoEffectController(
+                item,
+                [
+                    new ControllerPoint(
+                        new Vector3((float)currentX, (float)currentY, 0f),
+                        e =>
+                        {
+                            item.X.AddToEachValues(e.Delta.X);
+                            item.Y.AddToEachValues(e.Delta.Y);
+                        })
+                ]);
+
+            return effectDescription.DrawDescription with
+            {
+                Controllers =
+                [
+                    ..effectDescription.DrawDescription.Controllers,
+                    controller
+                ]
+            };
+        }
+
+        ID2D1Image? PrepareSametypeMask(
+            ID2D1DeviceContext dc,
+            RawRectF bounds,
+            int width,
+            int height,
+            double x,
+            double y,
+            double toleranceRaw,
+            double shapeThresholdRaw,
+            bool invert)
+        {
+            int pixelCount = width * height;
+            var mask = EnsureBuffers(pixelCount).Mask;
+
+            Vector4 matchColor = ReadSeedColor(dc, bounds, width, height, x, y, out int seedX, out int seedY);
+
+            bool foregroundChanged = isFirst
+                || !ColorWithinTolerance(matchColor, lastMatchColor, toleranceRaw)
+                || toleranceRaw != lastForegroundTolerance
+                || !lastBounds.Equals(bounds)
+                || currentInput != input;
+
+            int components;
+            if (foregroundChanged)
+            {
+                PrepareColorMatchEffect(matchColor, toleranceRaw);
+                var rendered = RenderForegroundToBuffer(dc, bounds, width, height);
+                components = pipeline.Analyze(rendered.AsSpan(0, pixelCount), width, height);
+                lastMatchColor = matchColor;
+                lastForegroundTolerance = toleranceRaw;
+                lastComponentCount = components;
+            }
+            else
+            {
+                components = lastComponentCount;
+            }
+
+            int seedIndex = ResolveSeedIndex(seedX, seedY, width, height);
+            if (components == 0 || seedIndex < 0)
+            {
+                Array.Clear(mask, 0, pixelCount);
+                EnsureFinalMaskBitmap(dc, width, height);
+                finalMaskBitmap!.CopyFromMemory<int>(mask, width * 4);
+                return TransformFinalMask(bounds);
+            }
+
+            bool maskChanged = pipeline.GenerateMask(
+                seedIndex,
+                (float)Math.Max(0, shapeThresholdRaw),
+                invert,
+                mask.AsSpan(0, pixelCount));
+
+            if (!maskChanged && finalMaskBitmap is not null)
+                return TransformFinalMask(bounds);
+
+            EnsureFinalMaskBitmap(dc, width, height);
+            finalMaskBitmap!.CopyFromMemory<int>(mask, width * 4);
+            return TransformFinalMask(bounds);
+        }
+
+        int ResolveSeedIndex(int seedX, int seedY, int width, int height)
+        {
+            if ((uint)seedX >= (uint)width || (uint)seedY >= (uint)height)
+                return -1;
+            return pipeline.IsForeground(seedY * width + seedX) ? seedY * width + seedX : -1;
+        }
+
+        static bool ColorWithinTolerance(Vector4 a, Vector4 b, double toleranceRaw)
+        {
+            float epsilon = (float)(Math.Clamp(toleranceRaw, 0, 255) / 255.0) * 0.25f;
+            return Math.Abs(a.X - b.X) <= epsilon
+                && Math.Abs(a.Y - b.Y) <= epsilon
+                && Math.Abs(a.Z - b.Z) <= epsilon
+                && Math.Abs(a.W - b.W) <= epsilon;
+        }
+
+        ID2D1Image? TransformFinalMask(RawRectF bounds)
+        {
+            if (finalMaskTransform is null || finalMaskTransformOutput is null || finalMaskBitmap is null)
+                return finalMaskBitmap;
+
+            finalMaskTransform.TransformMatrix = Matrix3x2.CreateTranslation(bounds.Left, bounds.Top);
+            finalMaskTransform.SetInput(0, finalMaskBitmap, true);
+            return finalMaskTransformOutput;
+        }
+
+        void PrepareColorMatchEffect(Vector4 targetColorVector, double toleranceRaw)
+        {
+            colorMatchEffect!.TargetColor = targetColorVector;
+            colorMatchEffect.Tolerance = (float)Math.Clamp(toleranceRaw, 0, 255) / 255f;
+            colorMatchEffect.Invert = 0f;
+            colorMatchEffect.SetInput(0, input, true);
+        }
+
+        void UpdateAlphaMask(ID2D1Image maskSource, double blurRadius)
+        {
+            if (blurRadius > 0.001 && blurEffect is not null)
+            {
+                blurEffect.StandardDeviation = (float)blurRadius;
+                blurEffect.SetInput(0, maskSource, true);
+                using var blurredMask = blurEffect.Output;
+                alphaMaskEffect!.SetInput(1, blurredMask, true);
+            }
+            else
+            {
+                blurEffect?.SetInput(0, null, true);
+                alphaMaskEffect!.SetInput(1, maskSource, true);
+            }
+        }
+
+        Vector4 ReadSeedColor(
+            ID2D1DeviceContext dc,
+            RawRectF bounds,
+            int width,
+            int height,
+            double x,
+            double y,
+            out int seedX,
+            out int seedY)
+        {
+            seedX = (int)Math.Round(x - bounds.Left);
+            seedY = (int)Math.Round(y - bounds.Top);
+            if ((uint)seedX >= (uint)width || (uint)seedY >= (uint)height) { seedX = seedY = 0; return default; }
+            float sourceX = bounds.Left + seedX;
+            float sourceY = bounds.Top + seedY;
+
+            EnsureSeedBitmaps(dc);
+
+            var previousTarget = dc.Target;
+            dc.Target = seedBitmap;
+            dc.BeginDraw();
+            dc.Clear(null);
+            dc.DrawImage(
+                input!,
+                new Vector2(-sourceX, -sourceY),
+                null,
+                InterpolationMode.NearestNeighbor,
+                CompositeMode.SourceCopy);
+            dc.EndDraw();
+            dc.Target = previousTarget;
+
+            seedStagingBitmap!.CopyFromBitmap(seedBitmap!);
+            var mapped = seedStagingBitmap.Map(MapOptions.Read);
+            try
+            {
+                Marshal.Copy(mapped.Bits, seedPixel, 0, 4);
+            }
+            finally
+            {
+                seedStagingBitmap.Unmap();
+            }
+
+            return new Vector4(
+                seedPixel[2] / 255f,
+                seedPixel[1] / 255f,
+                seedPixel[0] / 255f,
+                seedPixel[3] / 255f);
+        }
+
+        int[] RenderForegroundToBuffer(ID2D1DeviceContext dc, RawRectF bounds, int width, int height)
+        {
+            EnsureCandidateBitmaps(dc, width, height);
+            var foreground = EnsureBuffers(width * height).Foreground;
+
+            var previousTarget = dc.Target;
+            dc.Target = candidateBitmap;
+            dc.BeginDraw();
+            dc.Clear(null);
+            dc.DrawImage(
+                colorMatchOutput!,
+                new Vector2(-bounds.Left, -bounds.Top),
+                null,
+                InterpolationMode.NearestNeighbor,
+                CompositeMode.SourceCopy);
+            dc.EndDraw();
+            dc.Target = previousTarget;
+
+            candidateStagingBitmap!.CopyFromBitmap(candidateBitmap!);
+            var mapped = candidateStagingBitmap.Map(MapOptions.Read);
+            try
+            {
+                unsafe
+                {
+                    ForegroundExtractor.Extract((byte*)mapped.Bits, mapped.Pitch, width, height, foreground);
+                }
+            }
+            finally
+            {
+                candidateStagingBitmap.Unmap();
+            }
+
+            return foreground;
+        }
+
+        void EnsureFinalMaskBitmap(ID2D1DeviceContext dc, int width, int height)
+        {
+            if (finalMaskBitmap is not null && finalMaskWidth == width && finalMaskHeight == height)
+                return;
+
+            disposer.RemoveAndDispose(ref finalMaskBitmap);
+            var pixelFormat = new PixelFormat(Format.B8G8R8A8_UNorm, Vortice.DCommon.AlphaMode.Premultiplied);
+            finalMaskBitmap = dc.CreateBitmap(
+                new SizeI(width, height),
+                new BitmapProperties1(pixelFormat, 96f, 96f, BitmapOptions.None));
+            disposer.Collect(finalMaskBitmap);
+            finalMaskWidth = width;
+            finalMaskHeight = height;
+        }
+
+        void EnsureCandidateBitmaps(ID2D1DeviceContext dc, int width, int height)
+        {
+            if (candidateBitmap is not null
+                && candidateStagingBitmap is not null
+                && candidateWidth == width
+                && candidateHeight == height)
+                return;
+
+            disposer.RemoveAndDispose(ref candidateBitmap);
+            disposer.RemoveAndDispose(ref candidateStagingBitmap);
+
+            var pixelFormat = new PixelFormat(Format.B8G8R8A8_UNorm, Vortice.DCommon.AlphaMode.Premultiplied);
+            var size = new SizeI(width, height);
+
+            candidateBitmap = dc.CreateBitmap(
+                size,
+                new BitmapProperties1(pixelFormat, 96f, 96f, BitmapOptions.Target));
+            disposer.Collect(candidateBitmap);
+
+            candidateStagingBitmap = dc.CreateBitmap(
+                size,
+                new BitmapProperties1(pixelFormat, 96f, 96f, BitmapOptions.CpuRead | BitmapOptions.CannotDraw));
+            disposer.Collect(candidateStagingBitmap);
+
+            candidateWidth = width;
+            candidateHeight = height;
+        }
+
+        void EnsureSeedBitmaps(ID2D1DeviceContext dc)
+        {
+            if (seedBitmap is not null && seedStagingBitmap is not null)
+                return;
+
+            var pixelFormat = new PixelFormat(Format.B8G8R8A8_UNorm, Vortice.DCommon.AlphaMode.Premultiplied);
+            var size = new SizeI(1, 1);
+
+            seedBitmap = dc.CreateBitmap(
+                size,
+                new BitmapProperties1(pixelFormat, 96f, 96f, BitmapOptions.Target));
+            disposer.Collect(seedBitmap);
+
+            seedStagingBitmap = dc.CreateBitmap(
+                size,
+                new BitmapProperties1(pixelFormat, 96f, 96f, BitmapOptions.CpuRead | BitmapOptions.CannotDraw));
+            disposer.Collect(seedStagingBitmap);
+        }
+
+        (int[] Foreground, int[] Mask) EnsureBuffers(int pixelCount)
+        {
+            if (bufferPixelCount < pixelCount || foregroundBuffer is null || maskBuffer is null)
+            {
+                foregroundBuffer = new int[pixelCount];
+                maskBuffer = new int[pixelCount];
+                bufferPixelCount = pixelCount;
+            }
+
+            return (foregroundBuffer, maskBuffer);
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
@@ -582,7 +582,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
                 bufferPixelCount = pixelCount;
             }
 
-            return (foregroundBuffer!, maskBuffer!);
+            return (foregroundBuffer ?? (foregroundBuffer = new int[pixelCount]),
+                    maskBuffer ?? (maskBuffer = new int[pixelCount]));
         }
     }
 }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
@@ -361,16 +361,17 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
                 return TransformFinalMask(bounds);
             }
 
+            EnsureFinalMaskBitmap(dc, width, height);
+
             bool maskChanged = pipeline.GenerateMask(
                 seedIndex,
                 (float)Math.Max(0, shapeThresholdRaw),
                 invert,
                 mask.AsSpan(0, pixelCount));
 
-            if (!maskChanged && finalMaskBitmap is not null)
+            if (!maskChanged)
                 return TransformFinalMask(bounds);
 
-            EnsureFinalMaskBitmap(dc, width, height);
             finalMaskBitmap!.CopyFromMemory<int>(mask, width * 4);
             return TransformFinalMask(bounds);
         }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
@@ -582,8 +582,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
                 bufferPixelCount = pixelCount;
             }
 
-            return (foregroundBuffer ?? (foregroundBuffer = new int[pixelCount]),
-                    maskBuffer ?? (maskBuffer = new int[pixelCount]));
+            return (foregroundBuffer!, maskBuffer!);
         }
     }
 }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
@@ -276,6 +276,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
             }
             else
             {
+                disposer.RemoveAndDispose(ref luminanceCommandList);
                 outputEffect.SetInput(0, blendedCommandList, true);
             }
 

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
@@ -437,7 +437,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
         {
             seedX = (int)Math.Round(x - bounds.Left);
             seedY = (int)Math.Round(y - bounds.Top);
-            if ((uint)seedX >= (uint)width || (uint)seedY >= (uint)height) { seedX = seedY = 0; return default; }
+            if ((uint)seedX >= (uint)width || (uint)seedY >= (uint)height)
+                return default;
             float sourceX = bounds.Left + seedX;
             float sourceY = bounds.Top + seedY;
 

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
@@ -331,8 +331,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
             Vector4 matchColor = ReadSeedColor(dc, bounds, width, height, x, y, out int seedX, out int seedY);
 
             bool foregroundChanged = isFirst
-                || !ColorWithinTolerance(matchColor, lastMatchColor, toleranceRaw)
                 || toleranceRaw != lastForegroundTolerance
+                || !ColorWithinTolerance(matchColor, lastMatchColor, toleranceRaw)
                 || !lastBounds.Equals(bounds)
                 || currentInput != input;
 

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
@@ -134,6 +134,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
             outputEffect?.SetInput(0, null, true);
             alphaMaskEffect?.SetInput(0, null, true);
             alphaMaskEffect?.SetInput(1, null, true);
+            opacityEffect?.SetInput(0, null, true);
             luminanceMaskEffect?.SetInput(0, null, true);
             luminanceMaskEffect?.SetInput(1, null, true);
             blurEffect?.SetInput(0, null, true);

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/FillSametypeProcessor.cs
@@ -209,7 +209,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
                 return effectDescription.DrawDescription;
             }
 
-            if (isFirst || currentBlur != blur)
+            if (isFirst || needsMaskUpdate || currentBlur != blur)
                 UpdateAlphaMask(maskSource, currentBlur);
             if (isFirst || currentOpacity != opacity)
                 opacityEffect.Value = (float)(Math.Clamp(currentOpacity, 0, 100) / 100.0);

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/ForegroundExtractor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/ForegroundExtractor.cs
@@ -10,17 +10,20 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
         {
             fixed (int* destination = foreground)
             {
-                for (int y = 0; y < height; y++)
+                if (Avx2.IsSupported)
                 {
-                    byte* row = source + (nint)y * pitch;
-                    int* dst = destination + (nint)y * width;
-
-                    if (Avx2.IsSupported)
-                        ExtractRowAvx2(row, width, dst);
-                    else if (Sse2.IsSupported)
-                        ExtractRowSse2(row, width, dst);
-                    else
-                        ExtractRowScalar(row, width, dst, 0);
+                    for (int y = 0; y < height; y++)
+                        ExtractRowAvx2(source + (nint)y * pitch, width, destination + (nint)y * width);
+                }
+                else if (Sse2.IsSupported)
+                {
+                    for (int y = 0; y < height; y++)
+                        ExtractRowSse2(source + (nint)y * pitch, width, destination + (nint)y * width);
+                }
+                else
+                {
+                    for (int y = 0; y < height; y++)
+                        ExtractRowScalar(source + (nint)y * pitch, width, destination + (nint)y * width, 0);
                 }
             }
         }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/ForegroundExtractor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/ForegroundExtractor.cs
@@ -1,0 +1,69 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
+{
+    internal static unsafe class ForegroundExtractor
+    {
+        public static void Extract(byte* source, int pitch, int width, int height, int[] foreground)
+        {
+            fixed (int* destination = foreground)
+            {
+                for (int y = 0; y < height; y++)
+                {
+                    byte* row = source + (nint)y * pitch;
+                    int* dst = destination + (nint)y * width;
+
+                    if (Avx2.IsSupported)
+                        ExtractRowAvx2(row, width, dst);
+                    else if (Sse2.IsSupported)
+                        ExtractRowSse2(row, width, dst);
+                    else
+                        ExtractRowScalar(row, width, dst, 0);
+                }
+            }
+        }
+
+        static void ExtractRowAvx2(byte* row, int width, int* dst)
+        {
+            int x = 0;
+            var one = Vector256<int>.One;
+
+            for (; x <= width - 8; x += 8)
+            {
+                var bytes = Avx.LoadVector256(row + (nint)x * 4);
+                var alpha = Avx2.ShiftRightLogical(bytes.AsUInt32(), 24).AsInt32();
+                var mask = Avx2.CompareEqual(alpha, Vector256<int>.Zero);
+                var result = Avx2.AndNot(mask, one);
+                Avx.Store(dst + x, result);
+            }
+
+            ExtractRowScalar(row, width, dst, x);
+        }
+
+        static void ExtractRowSse2(byte* row, int width, int* dst)
+        {
+            int x = 0;
+            var one = Vector128<int>.One;
+
+            for (; x <= width - 4; x += 4)
+            {
+                var bytes = Sse2.LoadVector128(row + (nint)x * 4);
+                var alpha = Sse2.ShiftRightLogical(bytes.AsUInt32(), 24).AsInt32();
+                var mask = Sse2.CompareEqual(alpha, Vector128<int>.Zero);
+                var result = Sse2.AndNot(mask, one);
+                Sse2.Store(dst + x, result);
+            }
+
+            ExtractRowScalar(row, width, dst, x);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void ExtractRowScalar(byte* row, int width, int* dst, int start)
+        {
+            for (int x = start; x < width; x++)
+                dst[x] = row[x * 4 + 3] != 0 ? 1 : 0;
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/Texts.cs
@@ -1,0 +1,8 @@
+using YukkuriMovieMaker.Generator;
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FillSametype
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FillSametype/Texts.csv
@@ -1,0 +1,14 @@
+Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+FillSametypeEffectName,,同型塗りつぶし,Fill Same Shape,填充相同形状,填充相同形狀,같은 모양 채우기,Relleno de misma forma,تعبئة نفس الشكل,Isi Bentuk Sama
+FillSametypeTargetGroupName,,対象,Target,目标,目標,대상,Objetivo,الهدف,Target
+FillSametypeBrushGroupName,,模様,Pattern,图案,圖案,패턴,Patrón,نمط,Pola
+FillSametypeOpacityName,,不透明度,Opacity,不透明度,不透明度,불투명도,Opacidad,التعتيم,Opacity
+FillSametypeBlurName,,境界ぼかし,Edge Blur,边缘模糊,邊緣模糊,경계 블러,Desenfoque de borde,ضبابية الحافة,Blur Tepi
+FillSametypeBlendModeName,,合成モード,Blend Mode,混合模式,混合模式,혼합 모드,Modo de fusión,وضع المزج,Mode Blend
+FillSametypeIsInvertedName,,領域反転,Invert Region,反转区域,反轉區域,영역 반전,Invertir región,عكس المنطقة,Balik Wilayah
+FillSametypeIsBrushOnlyName,,模様のみ,Pattern Only,仅图案,僅圖案,패턴만,Solo patrón,النمط فقط,Pola Saja
+FillSametypePreserveLuminanceName,,輝度保持,Preserve Luminance,保持亮度,保持亮度,휘도 유지,Preservar luminancia,الحفاظ على اللمعان,Pertahankan Kecerahan
+FillSametypeXName,,X,X,X,X,X,X,X,X
+FillSametypeYName,,Y,Y,Y,Y,Y,Y,Y,Y
+FillSametypeToleranceName,,色許容範囲,Color Tolerance,颜色容差,顏色容差,색 허용 범위,Tolerancia de color,تسامح اللون,Toleransi Warna
+FillSametypeShapeThresholdName,,同型許容範囲,Shape Tolerance,形状容差,形狀容差,모양 허용 범위,Tolerancia de forma,تسامح الشكل,Toleransi Bentuk


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [x] このPRには1つの機能（または1つの修正）のみが含まれています
- [x] `YukkuriMovieMaker.dll`などYMM4本体の内部実装アセンブリを参照していません

## 概要
<!-- 変更内容を簡単に記載してください -->

新しい映像エフェクト「同型塗りつぶし」を追加します。
指定した座標にあるオブジェクトの色や形状を基準とし、画面内の類似する形状を自動的に検出して塗りつぶすことができる機能です。