### PR TITLE
「絵画調」映像エフェクトを高速化

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community.Shader/AnisotropicKuwahara.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/AnisotropicKuwahara.hlsl
@@ -15,16 +15,18 @@ SamplerState ColorSampler : register(s0);
 Texture2D TensorTexture : register(t1);
 SamplerState TensorSampler : register(s1);
 
+static const int SECTORS = 8;
+static const int MAX_SAMPLES = 1793;
+
 cbuffer Constants : register(b0)
 {
 	float radiusPx    : packoffset(c0.x); // 筆の半径(px)
 	float sharpness   : packoffset(c0.y); // 鮮鋭度 q
 	float anisotropy  : packoffset(c0.z); // 異方性 0..1
-	int   maxN        : packoffset(c0.w); // 片側サンプル数の上限(品質)
+	int   sampleCount : packoffset(c0.w);
+	float4 samples[MAX_SAMPLES] : packoffset(c1);
 };
 
-static const int SECTORS = 8;
-static const float PI    = 3.14159265358979323846f;
 // 色が [0,1] 正規化のため標準偏差は小さい。エッジ抑制を効かせるには
 // std を O(1) にスケールしてから応答関数 1/(1+(HARDNESS*std)^q) に通す。
 // この係数で std≈1/HARDNESS 付近を「エッジ判定のしきい値」とする。
@@ -70,55 +72,37 @@ float4 main(
 	float major = radiusPx * (1.0f + aniso); // エッジ接線方向(長軸)
 	float minor = radiusPx / (1.0f + aniso); // 勾配方向(短軸)
 
-	// --- サンプリング解像度(半径に比例、品質 maxN で上限を制御して負荷を抑制) ---
-	int N = (int)clamp(round(radiusPx), 1.0f, (float)max(maxN, 1));
-	float invN = 1.0f / (float)N;
+	float2 majorUv = major * tangent * texel;
+	float2 minorUv = minor * gradDir * texel;
 
 	// 扇形ごとの蓄積 (プリマルチプライ色をそのまま平均)
 	float4 mSum[SECTORS];
-	float4 m2Sum[SECTORS];
+	float3 m2Sum[SECTORS];
 	float  wSum[SECTORS];
 	[unroll]
 	for (int s = 0; s < SECTORS; s++)
 	{
 		mSum[s]  = float4(0.0f, 0.0f, 0.0f, 0.0f);
-		m2Sum[s] = float4(0.0f, 0.0f, 0.0f, 0.0f);
+		m2Sum[s] = float3(0.0f, 0.0f, 0.0f);
 		wSum[s]  = 0.0f;
 	}
 
-	float sectorScale = (float)SECTORS / (2.0f * PI);
-
 	[loop]
-	for (int j = -N; j <= N; j++)
+	for (int idx = 0; idx < sampleCount; idx++)
 	{
-		[loop]
-		for (int i = -N; i <= N; i++)
-		{
-			float2 u = float2((float)i, (float)j) * invN;
-			float r2 = dot(u, u);
-			if (r2 > 1.0f)
-				continue;
+		float4 sp = samples[idx];
+		float4 c = SampleColor(uv0.xy + sp.x * majorUv + sp.y * minorUv);
 
-			// 楕円へ変形して色をサンプル
-			float2 offsetPx = u.x * major * tangent + u.y * minor * gradDir;
-			float4 c = SampleColor(uv0.xy + offsetPx * texel);
+		int k0 = (int)sp.w;
+		int k1 = (k0 + 1) & (SECTORS - 1);
+		float fr = sp.w - (float)k0;
 
-			// 角度 -> 扇形(隣接2扇形へ線形ブレンド)。SECTORS=8 は 2 の冪なので & 7 で剰余
-			float ang = atan2(u.y, u.x) + PI;        // [0, 2PI)
-			float sf = ang * sectorScale;            // [0, SECTORS)
-			int k0 = (int)floor(sf) & (SECTORS - 1);
-			int k1 = (k0 + 1) & (SECTORS - 1);
-			float fr = frac(sf);
+		float w0 = sp.z * (1.0f - fr);
+		float w1 = sp.z * fr;
 
-			// 中心(r2 が小さい)ほどわずかに重くして滑らかに
-			float wr = exp(-2.0f * r2);
-			float w0 = wr * (1.0f - fr);
-			float w1 = wr * fr;
-
-			float4 c2 = c * c;
-			mSum[k0]  += w0 * c;   m2Sum[k0] += w0 * c2;  wSum[k0] += w0;
-			mSum[k1]  += w1 * c;   m2Sum[k1] += w1 * c2;  wSum[k1] += w1;
-		}
+		float3 c2 = c.rgb * c.rgb;
+		mSum[k0]  += w0 * c;   m2Sum[k0] += w0 * c2;  wSum[k0] += w0;
+		mSum[k1]  += w1 * c;   m2Sum[k1] += w1 * c2;  wSum[k1] += w1;
 	}
 
 	// --- 分散が小さい扇形ほど大きい重みで加重平均 ---
@@ -133,7 +117,7 @@ float4 main(
 		if (wk < 1e-6f)
 			continue;
 		float4 mean = mSum[k] / wk;
-		float4 var = max(m2Sum[k] / wk - mean * mean, 0.0f);
+		float3 var = max(m2Sum[k] / wk - mean.rgb * mean.rgb, 0.0f);
 		float sigma2 = var.r + var.g + var.b;
 		float sigma = sqrt(sigma2);
 		// 分散が小さい(=均質な)扇形ほど大きい重み。HARDNESS で std を O(1) に

--- a/YukkuriMovieMaker.Plugin.Community.Shader/AnisotropicKuwahara.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/AnisotropicKuwahara.hlsl
@@ -16,6 +16,7 @@ Texture2D TensorTexture : register(t1);
 SamplerState TensorSampler : register(s1);
 
 static const int SECTORS = 8;
+// 半径24の円内格子点数 N(24)=1793。C#側 MaxSampleCount と一致させること(導出はそちらのコメント参照)
 static const int MAX_SAMPLES = 1793;
 
 cbuffer Constants : register(b0)

--- a/YukkuriMovieMaker.Plugin.Community.Shader/AnisotropicKuwaharaTensorBlur.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/AnisotropicKuwaharaTensorBlur.hlsl
@@ -11,6 +11,11 @@
 Texture2D InputTexture : register(t0);
 SamplerState InputSampler : register(s0);
 
+cbuffer Constants : register(b0)
+{
+	float2 dir : packoffset(c0);
+};
+
 static const int   BLUR_RADIUS = 5;
 static const float BLUR_SIGMA  = 2.6f;
 
@@ -35,17 +40,13 @@ float4 main(
 	float4 sum = float4(0.0f, 0.0f, 0.0f, 0.0f);
 	float wsum = 0.0f;
 
-	[loop]
-	for (int j = -BLUR_RADIUS; j <= BLUR_RADIUS; j++)
+	[unroll]
+	for (int i = -BLUR_RADIUS; i <= BLUR_RADIUS; i++)
 	{
-		[loop]
-		for (int i = -BLUR_RADIUS; i <= BLUR_RADIUS; i++)
-		{
-			float2 o = float2((float)i, (float)j);
-			float w = exp(-dot(o, o) * inv2s2);
-			sum += w * SampleTensor(c + o * t);
-			wsum += w;
-		}
+		float2 o = dir * (float)i;
+		float w = exp(-dot(o, o) * inv2s2);
+		sum += w * SampleTensor(c + o * t);
+		wsum += w;
 	}
 
 	return sum / max(wsum, 1e-6f);

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AnisotropicKuwahara/AnisotropicKuwaharaCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AnisotropicKuwahara/AnisotropicKuwaharaCustomEffect.cs
@@ -34,10 +34,17 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AnisotropicKuwahara
         [CustomEffect(2)]
         private sealed class EffectImpl : D2D1CustomShaderEffectImplBase<EffectImpl>
         {
+            const int Sectors = 8;
+            const int MaxNLimit = 24;
+            const int MaxSampleCount = 1793;
+
             private ConstantBuffer _cb;
+            private float _radius;
+            private int _maxN = MaxNLimit;
+            private int _tableN;
 
             [CustomEffectProperty(PropertyType.Float, (int)Properties.Radius)]
-            public float Radius { get => _cb.RadiusPx; set { _cb.RadiusPx = Math.Max(value, 0f); UpdateConstants(); } }
+            public float Radius { get => _radius; set { _radius = Math.Max(value, 0f); _cb.RadiusPx = _radius; UpdateSampleTable(); UpdateConstants(); } }
 
             [CustomEffectProperty(PropertyType.Float, (int)Properties.Sharpness)]
             public float Sharpness { get => _cb.Sharpness; set { _cb.Sharpness = Math.Max(value, 0f); UpdateConstants(); } }
@@ -46,10 +53,52 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AnisotropicKuwahara
             public float Anisotropy { get => _cb.Anisotropy; set { _cb.Anisotropy = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
 
             [CustomEffectProperty(PropertyType.Int32, (int)Properties.MaxN)]
-            public int MaxN { get => _cb.MaxN; set { _cb.MaxN = Math.Clamp(value, 1, 24); UpdateConstants(); } }
+            public int MaxN { get => _maxN; set { _maxN = Math.Clamp(value, 1, MaxNLimit); UpdateSampleTable(); UpdateConstants(); } }
 
             public EffectImpl() : base(ShaderResourceUri.Get("AnisotropicKuwahara"))
             {
+                UpdateSampleTable();
+            }
+
+            private void UpdateSampleTable()
+            {
+                var n = Math.Clamp((int)Math.Round(_radius), 1, _maxN);
+                if (n == _tableN)
+                    return;
+                _tableN = n;
+
+                var count = 0;
+                var sectorScale = Sectors / (2.0 * Math.PI);
+                unsafe
+                {
+                    fixed (float* samples = _cb.Samples)
+                    {
+                        for (var j = -n; j <= n; j++)
+                        {
+                            for (var i = -n; i <= n; i++)
+                            {
+                                if (i * i + j * j > n * n)
+                                    continue;
+
+                                var ux = (double)i / n;
+                                var uy = (double)j / n;
+                                var r2 = ux * ux + uy * uy;
+                                var wr = Math.Exp(-2.0 * r2);
+                                var sf = (Math.Atan2(uy, ux) + Math.PI) * sectorScale;
+                                if (sf >= Sectors)
+                                    sf -= Sectors;
+
+                                var p = samples + count * 4;
+                                p[0] = (float)ux;
+                                p[1] = (float)uy;
+                                p[2] = (float)wr;
+                                p[3] = (float)sf;
+                                count++;
+                            }
+                        }
+                    }
+                }
+                _cb.SampleCount = count;
             }
 
             protected override void UpdateConstants()
@@ -74,12 +123,13 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AnisotropicKuwahara
             }
 
             [StructLayout(LayoutKind.Sequential)]
-            private struct ConstantBuffer
+            private unsafe struct ConstantBuffer
             {
                 public float RadiusPx;
                 public float Sharpness;
                 public float Anisotropy;
-                public int MaxN;
+                public int SampleCount;
+                public fixed float Samples[MaxSampleCount * 4];
             }
 
             public enum Properties : int

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AnisotropicKuwahara/AnisotropicKuwaharaCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AnisotropicKuwahara/AnisotropicKuwaharaCustomEffect.cs
@@ -36,6 +36,11 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AnisotropicKuwahara
         {
             const int Sectors = 8;
             const int MaxNLimit = 24;
+            // サンプルは半径 n(≤MaxNLimit) の円内格子点。バッファ上限はその最大 N(MaxNLimit)。
+            //   N(r) = Σ_{i=-r..r} ( 2*floor(sqrt(r*r - i*i)) + 1 )   … i²+j²≤r² の格子点数(ガウスの円問題)
+            // 閉じた式が無く floor/sqrt を含むため const 式にできず直値。N(24)=1793。
+            // MaxNLimit を変える場合は上式で N(MaxNLimit) を再計算して更新し、シェーダー側 MAX_SAMPLES とも一致させること。
+            // 万一の不整合に備え、書き込みループは count < MaxSampleCount で保護している。
             const int MaxSampleCount = 1793;
 
             private ConstantBuffer _cb;
@@ -73,9 +78,9 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AnisotropicKuwahara
                 {
                     fixed (float* samples = _cb.Samples)
                     {
-                        for (var j = -n; j <= n; j++)
+                        for (var j = -n; j <= n && count < MaxSampleCount; j++)
                         {
-                            for (var i = -n; i <= n; i++)
+                            for (var i = -n; i <= n && count < MaxSampleCount; i++)
                             {
                                 if (i * i + j * j > n * n)
                                     continue;

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AnisotropicKuwahara/AnisotropicKuwaharaEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AnisotropicKuwahara/AnisotropicKuwaharaEffectProcessor.cs
@@ -9,7 +9,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AnisotropicKuwahara
     {
         // パス1: 構造テンソル -> パス2: 平滑化 -> パス3: 本体(入力0=元画像, 入力1=平滑テンソル)
         AnisotropicKuwaharaTensorCustomEffect? tensorEffect;
-        AnisotropicKuwaharaTensorBlurCustomEffect? tensorBlurEffect;
+        AnisotropicKuwaharaTensorBlurCustomEffect? tensorBlurXEffect;
+        AnisotropicKuwaharaTensorBlurCustomEffect? tensorBlurYEffect;
         AnisotropicKuwaharaCustomEffect? kuwaharaEffect;
 
         bool isFirst = true;
@@ -63,29 +64,38 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AnisotropicKuwahara
         protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
         {
             tensorEffect = new AnisotropicKuwaharaTensorCustomEffect(devices);
-            tensorBlurEffect = new AnisotropicKuwaharaTensorBlurCustomEffect(devices);
+            tensorBlurXEffect = new AnisotropicKuwaharaTensorBlurCustomEffect(devices);
+            tensorBlurYEffect = new AnisotropicKuwaharaTensorBlurCustomEffect(devices);
             kuwaharaEffect = new AnisotropicKuwaharaCustomEffect(devices);
 
-            if (!tensorEffect.IsEnabled || !tensorBlurEffect.IsEnabled || !kuwaharaEffect.IsEnabled)
+            if (!tensorEffect.IsEnabled || !tensorBlurXEffect.IsEnabled || !tensorBlurYEffect.IsEnabled || !kuwaharaEffect.IsEnabled)
             {
                 tensorEffect.Dispose();
-                tensorBlurEffect.Dispose();
+                tensorBlurXEffect.Dispose();
+                tensorBlurYEffect.Dispose();
                 kuwaharaEffect.Dispose();
                 tensorEffect = null;
-                tensorBlurEffect = null;
+                tensorBlurXEffect = null;
+                tensorBlurYEffect = null;
                 kuwaharaEffect = null;
                 return null;
             }
 
             disposer.Collect(tensorEffect);
-            disposer.Collect(tensorBlurEffect);
+            disposer.Collect(tensorBlurXEffect);
+            disposer.Collect(tensorBlurYEffect);
             disposer.Collect(kuwaharaEffect);
+
+            tensorBlurXEffect.IsVertical = false;
+            tensorBlurYEffect.IsVertical = true;
 
             // テンソル -> 平滑化 -> 本体の入力1
             using (var tensorOutput = tensorEffect.Output)
-                tensorBlurEffect.SetInput(0, tensorOutput, true);
-            using (var blurOutput = tensorBlurEffect.Output)
-                kuwaharaEffect.SetInput(1, blurOutput, true);
+                tensorBlurXEffect.SetInput(0, tensorOutput, true);
+            using (var blurXOutput = tensorBlurXEffect.Output)
+                tensorBlurYEffect.SetInput(0, blurXOutput, true);
+            using (var blurYOutput = tensorBlurYEffect.Output)
+                kuwaharaEffect.SetInput(1, blurYOutput, true);
 
             var output = kuwaharaEffect.Output;
             disposer.Collect(output);
@@ -102,7 +112,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AnisotropicKuwahara
         protected override void ClearEffectChain()
         {
             tensorEffect?.SetInput(0, null, true);
-            tensorBlurEffect?.SetInput(0, null, true);
+            tensorBlurXEffect?.SetInput(0, null, true);
+            tensorBlurYEffect?.SetInput(0, null, true);
             kuwaharaEffect?.SetInput(0, null, true);
             kuwaharaEffect?.SetInput(1, null, true);
         }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/AnisotropicKuwahara/AnisotropicKuwaharaTensorBlurCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/AnisotropicKuwahara/AnisotropicKuwaharaTensorBlurCustomEffect.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Vortice;
 using Vortice.Direct2D1;
 using YukkuriMovieMaker.Commons;
@@ -6,14 +7,29 @@ using YukkuriMovieMaker.Plugin.Community.Commons;
 
 namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AnisotropicKuwahara
 {
-    // パス2: 構造テンソルをガウス平滑化してオリエンテーションを安定化。パラメータ無し。
+    // パス2: 構造テンソルをガウス平滑化してオリエンテーションを安定化。
     internal sealed class AnisotropicKuwaharaTensorBlurCustomEffect(IGraphicsDevicesAndContext devices) : D2D1CustomShaderEffectBase(Create<EffectImpl>(devices))
     {
+        public bool IsVertical
+        {
+            set => SetValue((int)EffectImpl.Properties.IsVertical, value);
+            get => GetBoolValue((int)EffectImpl.Properties.IsVertical);
+        }
+
         [CustomEffect(1)]
         private sealed class EffectImpl : D2D1CustomShaderEffectImplBase<EffectImpl>
         {
             // シェーダー側 BLUR_RADIUS と一致させること
             const int ReadRadius = 5;
+
+            private ConstantBuffer _cb = new() { DirX = 1f, DirY = 0f };
+
+            [CustomEffectProperty(PropertyType.Bool, (int)Properties.IsVertical)]
+            public bool IsVertical
+            {
+                get => _cb.DirY != 0f;
+                set { _cb.DirX = value ? 0f : 1f; _cb.DirY = value ? 1f : 0f; UpdateConstants(); }
+            }
 
             public EffectImpl() : base(ShaderResourceUri.Get("AnisotropicKuwaharaTensorBlur"))
             {
@@ -21,16 +37,30 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.AnisotropicKuwahara
 
             protected override void UpdateConstants()
             {
-                // 定数バッファ無し
+                drawInformation?.SetPixelShaderConstantBuffer(_cb);
             }
 
             public override void MapOutputRectToInputRects(RawRect outputRect, RawRect[] inputRects)
             {
+                var padX = IsVertical ? 0 : ReadRadius + 1;
+                var padY = IsVertical ? ReadRadius + 1 : 0;
                 inputRects[0] = new RawRect(
-                    outputRect.Left - ReadRadius - 1,
-                    outputRect.Top - ReadRadius - 1,
-                    outputRect.Right + ReadRadius + 1,
-                    outputRect.Bottom + ReadRadius + 1);
+                    outputRect.Left - padX,
+                    outputRect.Top - padY,
+                    outputRect.Right + padX,
+                    outputRect.Bottom + padY);
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            private struct ConstantBuffer
+            {
+                public float DirX;
+                public float DirY;
+            }
+
+            public enum Properties : int
+            {
+                IsVertical = 0,
             }
         }
     }


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [x] このPRには1つの機能（または1つの修正）のみが含まれています
- [x] `YukkuriMovieMaker.dll`などYMM4本体の内部実装アセンブリを参照していません

## 概要
<!-- 変更内容を簡単に記載してください -->

絵画調エフェクトのパラメータ変更時・シーク時の描画負荷を改善します。アルゴリズムは一切変更しておらず、出力品質は維持したまま、GPUの画素毎ループから冗長な計算を排除する方針で全パスを見直しました。

## 変更内容

### 構造テンソル平滑化の分離可能ガウス化
- `AnisotropicKuwaharaTensorBlur.hlsl` を11×11の2次元ガウスから、方向定数 `dir` を持つ1次元ガウスに変更
- `AnisotropicKuwaharaTensorBlurCustomEffect` に `IsVertical` プロパティを追加し、プロセッサで水平->垂直の2インスタンスを直列接続
- `MapOutputRectToInputRects` の入力矩形拡張も方向別に変更
- ガウスカーネルは分離可能なため結果は数学的に等価。境界外を定数 (0, 0, 0.5) として扱う仕様も、定数はぼかしで不変のため分離後も一致します

### 本体のサンプル格子テーブルの事前計算
- 内側ループで毎回計算していた `atan2`・`exp`・`floor`・円外判定は、画素に依存せずサンプル格子の形状のみで決まる値のため、C#側で事前計算し、定数バッファのテーブルとしてシェーダーへ渡す構成に変更
- シェーダーの内側ループはテーブル参照->楕円変換->テクスチャサンプル->蓄積のみとなり、円外の空回りイテレーションも解消
- テーブルはサンプル数Nが変化した時のみ再生成。Nは `clamp(round(radius), 1, maxN)` で従来シェーダー内と同じ式のため、半径スライダー操作の大半では再生成が発生しません
- 分散の蓄積を実際に使用するRGBのみに縮小し、レジスタ使用量を削減

### 品質
- サンプル位置・重み・扇形ブレンド・分散重み付けの式は変更なし。角度・重みの計算がGPUのfloat演算からCPUのdouble演算に移るため、最下位ビットレベルの数値差は生じ得ますが、視覚上の差はありません
- テンソル平滑化の2パス化により、中間バッファでの量子化が1回増えます。対象はオリエンテーション推定用のテンソルのみで、量子化誤差は1/255未満です