### PR TITLE
映像エフェクト「クロスハッチ陰影」を追加

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community.Shader/CrossHatchShading.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/CrossHatchShading.hlsl
@@ -1,0 +1,232 @@
+Texture2D InputTexture : register(t0);
+SamplerState InputSampler : register(s0);
+
+cbuffer Constants : register(b0)
+{
+    float amount : packoffset(c0.x);
+    float density : packoffset(c0.y);
+    float thickness : packoffset(c0.z);
+    float shadowDepth : packoffset(c0.w);
+    float flow : packoffset(c1.x);
+    float outline : packoffset(c1.y);
+    float toneSoftness : packoffset(c1.z);
+    float grain : packoffset(c1.w);
+    int seed : packoffset(c2.x);
+    int style : packoffset(c2.y);
+    int colorMode : packoffset(c2.z);
+    int lineLayers : packoffset(c2.w);
+    float4 inkColor : packoffset(c3);
+    float4 paperColor : packoffset(c4);
+    float4 inputBounds : packoffset(c5);
+    float wobble : packoffset(c6.x);
+};
+
+static const float3 LumaWeight = float3(0.2126, 0.7152, 0.0722);
+static const float GradientLow = 0.015;
+static const float GradientHigh = 0.150;
+static const float EdgeThreshold = 0.080;
+static const float EdgeSoftness = 0.140;
+static const float AlphaEdgeWeight = 1.4;
+static const float PaperNoiseDepth = 0.06;
+static const float WobbleAmplitude = 0.45;
+static const float WobbleWidthDepth = 0.35;
+
+uint Hash32(uint value)
+{
+    value ^= value >> 16;
+    value *= 0x7feb352du;
+    value ^= value >> 15;
+    value *= 0x846ca68bu;
+    value ^= value >> 16;
+    return value;
+}
+
+float Hash01(int value)
+{
+    return Hash32(asuint(value)) * (1.0 / 4294967296.0);
+}
+
+float CellNoise(int2 cell)
+{
+    uint hash = Hash32(asuint(cell.x) * 0x9e3779b9u ^ Hash32(asuint(cell.y) * 0x85ebca6bu ^ asuint(seed)));
+    return hash * (1.0 / 4294967296.0);
+}
+
+float ValueNoise(float2 position)
+{
+    float2 cell = floor(position);
+    float2 fraction = position - cell;
+    float2 weight = fraction * fraction * (3.0 - 2.0 * fraction);
+    int2 base = int2(cell);
+    float n00 = CellNoise(base);
+    float n10 = CellNoise(base + int2(1, 0));
+    float n01 = CellNoise(base + int2(0, 1));
+    float n11 = CellNoise(base + int2(1, 1));
+    return lerp(lerp(n00, n10, weight.x), lerp(n01, n11, weight.x), weight.y);
+}
+
+void GetStyle(int value, out float4 anglesDeg, out float4 thresholds, out float grainScale, out float outlineScale, out float crossBoost)
+{
+    if (value == 1)
+    {
+        anglesDeg = float4(20.0, -20.0, 70.0, -70.0);
+        thresholds = float4(0.18, 0.36, 0.56, 0.76);
+        grainScale = 1.0;
+        outlineScale = 0.6;
+        crossBoost = 0.35;
+    }
+    else if (value == 2)
+    {
+        anglesDeg = float4(-45.0, 45.0, 0.0, 90.0);
+        thresholds = float4(0.30, 0.50, 0.70, 0.86);
+        grainScale = 0.5;
+        outlineScale = 1.4;
+        crossBoost = 0.0;
+    }
+    else if (value == 3)
+    {
+        anglesDeg = float4(0.0, 90.0, 45.0, -45.0);
+        thresholds = float4(0.22, 0.44, 0.66, 0.84);
+        grainScale = 0.35;
+        outlineScale = 1.4;
+        crossBoost = 0.0;
+    }
+    else
+    {
+        anglesDeg = float4(-45.0, 45.0, 0.0, 90.0);
+        thresholds = float4(0.25, 0.45, 0.65, 0.82);
+        grainScale = 0.6;
+        outlineScale = 1.0;
+        crossBoost = 0.0;
+    }
+}
+
+float4 SampleScene(float2 uv, float2 pixelStep, float2 scenePosition, float2 offset)
+{
+    float2 minimum = inputBounds.xy + 0.5;
+    float2 maximum = max(inputBounds.zw - 0.5, minimum);
+    float2 target = clamp(scenePosition + offset, minimum, maximum);
+    return InputTexture.SampleLevel(InputSampler, uv + (target - scenePosition) * pixelStep, 0);
+}
+
+float2 Straighten(float4 premultiplied)
+{
+    float alpha = max(premultiplied.a, 1e-5);
+    float luma = dot(saturate(premultiplied.rgb / alpha), LumaWeight);
+    return float2(luma, saturate(premultiplied.a));
+}
+
+float2 Rotate(float2 direction, float angle)
+{
+    float c = cos(angle);
+    float s = sin(angle);
+    return float2(direction.x * c - direction.y * s, direction.x * s + direction.y * c);
+}
+
+float4 main(
+    float4 position : SV_POSITION,
+    float4 scenePosition : SCENE_POSITION,
+    float4 uv0 : TEXCOORD0
+) : SV_TARGET
+{
+    float4 source = InputTexture.SampleLevel(InputSampler, uv0.xy, 0);
+    if (amount <= 0.0 || source.a <= 0.0)
+        return source;
+
+    float2 scene = scenePosition.xy;
+    float2 pixelStep = uv0.zw;
+
+    float2 n00 = Straighten(SampleScene(uv0.xy, pixelStep, scene, float2(-1.0, -1.0)));
+    float2 n10 = Straighten(SampleScene(uv0.xy, pixelStep, scene, float2(0.0, -1.0)));
+    float2 n20 = Straighten(SampleScene(uv0.xy, pixelStep, scene, float2(1.0, -1.0)));
+    float2 n01 = Straighten(SampleScene(uv0.xy, pixelStep, scene, float2(-1.0, 0.0)));
+    float2 n21 = Straighten(SampleScene(uv0.xy, pixelStep, scene, float2(1.0, 0.0)));
+    float2 n02 = Straighten(SampleScene(uv0.xy, pixelStep, scene, float2(-1.0, 1.0)));
+    float2 n12 = Straighten(SampleScene(uv0.xy, pixelStep, scene, float2(0.0, 1.0)));
+    float2 n22 = Straighten(SampleScene(uv0.xy, pixelStep, scene, float2(1.0, 1.0)));
+
+    float2 center = Straighten(source);
+    float luma = center.x;
+
+    const float kA = 3.0 / 16.0;
+    const float kB = 10.0 / 16.0;
+    float2 gradX = (n20 * kA + n21 * kB + n22 * kA) - (n00 * kA + n01 * kB + n02 * kA);
+    float2 gradY = (n02 * kA + n12 * kB + n22 * kA) - (n00 * kA + n10 * kB + n20 * kA);
+
+    float lumaGradient = length(float2(gradX.x, gradY.x));
+    float2 flowTangent = lumaGradient > 1e-5 ? normalize(float2(-gradY.x, gradX.x)) : float2(1.0, 0.0);
+    float flowWeight = flow * smoothstep(GradientLow, GradientHigh, lumaGradient);
+
+    float4 anglesDeg;
+    float4 thresholds;
+    float grainScale;
+    float outlineScale;
+    float crossBoost;
+    GetStyle(style, anglesDeg, thresholds, grainScale, outlineScale, crossBoost);
+
+    float angles[4] = { radians(anglesDeg.x), radians(anglesDeg.y), radians(anglesDeg.z), radians(anglesDeg.w) };
+    float thresholdArray[4] = { thresholds.x, thresholds.y, thresholds.z, thresholds.w };
+    float layerOffset[4] = { 0.0, radians(90.0), radians(45.0), radians(-45.0) };
+
+    float2 seedOffset = float2(Hash01(seed * 2 + 1), Hash01(seed * 2 + 3)) * 1024.0;
+    float2 patternPosition = scene + seedOffset;
+    float shade = saturate((1.0 - luma) * shadowDepth);
+    float safeDensity = max(density, 1e-3);
+    float wobbleFrequency = 0.35 / safeDensity;
+
+    float hatchMax = 0.0;
+    float hatchSum = 0.0;
+
+    [unroll]
+    for (int i = 0; i < 4; ++i)
+    {
+        float2 fixedDir = float2(cos(angles[i]), sin(angles[i]));
+        float2 flowDir = Rotate(flowTangent, layerOffset[i]);
+        float2 direction = normalize(lerp(fixedDir, flowDir, flowWeight));
+
+        float wobbleNoise = ValueNoise(patternPosition * wobbleFrequency + i * 17.0) - 0.5;
+        float projection = dot(patternPosition, direction) + Hash01(seed * 4 + i) * safeDensity;
+        projection += wobble * wobbleNoise * safeDensity * WobbleAmplitude;
+        float halfWidth = thickness * 0.5 * (1.0 + wobble * wobbleNoise * WobbleWidthDepth);
+        float coordinate = projection / safeDensity;
+        float distancePx = abs(frac(coordinate) - 0.5) * safeDensity;
+        float aa = max(fwidth(projection), 1.0) * 0.5;
+        float lineMask = 1.0 - smoothstep(halfWidth - aa, halfWidth + aa, distancePx);
+
+        bool active = (lineLayers == 0) || (i < lineLayers);
+        float layerWeight = active ? smoothstep(thresholdArray[i], thresholdArray[i] + toneSoftness + 1e-4, shade) : 0.0;
+        float contribution = lineMask * layerWeight;
+
+        hatchMax = max(hatchMax, contribution);
+        hatchSum += contribution;
+    }
+
+    float hatch = saturate(hatchMax + crossBoost * max(hatchSum - hatchMax, 0.0));
+
+    float effectiveGrain = saturate(grain * grainScale);
+    float noise = CellNoise(int2(floor(patternPosition)));
+    float inkBreak = lerp(1.0, smoothstep(0.15, 0.95, noise), effectiveGrain);
+    float paperNoise = (noise - 0.5) * effectiveGrain * PaperNoiseDepth;
+
+    float alphaGradient = length(float2(gradX.y, gradY.y));
+    float edgeMagnitude = sqrt(lumaGradient * lumaGradient + alphaGradient * alphaGradient * AlphaEdgeWeight);
+    float edge = smoothstep(EdgeThreshold, EdgeThreshold + EdgeSoftness, edgeMagnitude) * saturate(outline * outlineScale);
+
+    float inkMask = saturate(max(hatch * inkBreak, edge));
+
+    float3 sourceRgb = source.rgb / max(source.a, 1e-5);
+    float3 styledRgb;
+    if (colorMode == 0)
+    {
+        float3 paperRgb = saturate(paperColor.rgb + paperNoise);
+        styledRgb = lerp(paperRgb, inkColor.rgb, inkMask);
+    }
+    else
+    {
+        styledRgb = lerp(sourceRgb, inkColor.rgb, inkMask);
+    }
+
+    float3 outRgb = lerp(sourceRgb, styledRgb, amount);
+    float outAlpha = source.a;
+    return float4(saturate(outRgb) * outAlpha, outAlpha);
+}

--- a/YukkuriMovieMaker.Plugin.Community.Shader/CrossHatchShading.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/CrossHatchShading.hlsl
@@ -182,6 +182,7 @@ float4 main(
     {
         float2 fixedDir = float2(cos(angles[i]), sin(angles[i]));
         float2 flowDir = Rotate(flowTangent, layerOffset[i]);
+        flowDir = dot(flowDir, fixedDir) < 0.0 ? -flowDir : flowDir;
         float2 direction = normalize(lerp(fixedDir, flowDir, flowWeight));
 
         float wobbleNoise = ValueNoise(patternPosition * wobbleFrequency + i * 17.0) - 0.5;

--- a/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj
@@ -311,6 +311,12 @@
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
     </FxCompile>
+	<FxCompile Include="CrossHatchShading.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+    </FxCompile>
 	<FxCompile Include="GradientMap.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Pixel</ShaderType>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>

--- a/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj.filters
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj.filters
@@ -99,6 +99,9 @@
     <FxCompile Include="WaveClipping.hlsl">
       <Filter>ソース ファイル</Filter>
     </FxCompile>
+    <FxCompile Include="CrossHatchShading.hlsl">
+      <Filter>ソース ファイル</Filter>
+    </FxCompile>
     <FxCompile Include="GradientMap.hlsl">
       <Filter>ソース ファイル</Filter>
     </FxCompile>

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/CrossHatchColorMode.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/CrossHatchColorMode.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossHatchShading
+{
+    public enum CrossHatchColorMode
+    {
+        [Display(Name = nameof(Texts.CrossHatchShadingColorModeInkAndPaper), Description = nameof(Texts.CrossHatchShadingColorModeInkAndPaperDesc), ResourceType = typeof(Texts))]
+        InkAndPaper = 0,
+
+        [Display(Name = nameof(Texts.CrossHatchShadingColorModePreserveSource), Description = nameof(Texts.CrossHatchShadingColorModePreserveSourceDesc), ResourceType = typeof(Texts))]
+        PreserveSource = 1,
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/CrossHatchLineLayers.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/CrossHatchLineLayers.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossHatchShading
+{
+    public enum CrossHatchLineLayers
+    {
+        [Display(Name = nameof(Texts.CrossHatchShadingLineLayersAuto), ResourceType = typeof(Texts))]
+        Auto = 0,
+
+        [Display(Name = nameof(Texts.CrossHatchShadingLineLayers1), ResourceType = typeof(Texts))]
+        One = 1,
+
+        [Display(Name = nameof(Texts.CrossHatchShadingLineLayers2), ResourceType = typeof(Texts))]
+        Two = 2,
+
+        [Display(Name = nameof(Texts.CrossHatchShadingLineLayers3), ResourceType = typeof(Texts))]
+        Three = 3,
+
+        [Display(Name = nameof(Texts.CrossHatchShadingLineLayers4), ResourceType = typeof(Texts))]
+        Four = 4,
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/CrossHatchShadingCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/CrossHatchShadingCustomEffect.cs
@@ -1,0 +1,179 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+using Vortice;
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Commons;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossHatchShading
+{
+    internal sealed class CrossHatchShadingCustomEffect(IGraphicsDevicesAndContext devices) : D2D1CustomShaderEffectBase(Create<EffectImpl>(devices))
+    {
+        public float Amount { get => GetFloatValue((int)EffectImpl.Properties.Amount); set => SetValue((int)EffectImpl.Properties.Amount, value); }
+        public float Density { get => GetFloatValue((int)EffectImpl.Properties.Density); set => SetValue((int)EffectImpl.Properties.Density, value); }
+        public float Thickness { get => GetFloatValue((int)EffectImpl.Properties.Thickness); set => SetValue((int)EffectImpl.Properties.Thickness, value); }
+        public float ShadowDepth { get => GetFloatValue((int)EffectImpl.Properties.ShadowDepth); set => SetValue((int)EffectImpl.Properties.ShadowDepth, value); }
+        public float Flow { get => GetFloatValue((int)EffectImpl.Properties.Flow); set => SetValue((int)EffectImpl.Properties.Flow, value); }
+        public float Wobble { get => GetFloatValue((int)EffectImpl.Properties.Wobble); set => SetValue((int)EffectImpl.Properties.Wobble, value); }
+        public float Outline { get => GetFloatValue((int)EffectImpl.Properties.Outline); set => SetValue((int)EffectImpl.Properties.Outline, value); }
+        public float ToneSoftness { get => GetFloatValue((int)EffectImpl.Properties.ToneSoftness); set => SetValue((int)EffectImpl.Properties.ToneSoftness, value); }
+        public float Grain { get => GetFloatValue((int)EffectImpl.Properties.Grain); set => SetValue((int)EffectImpl.Properties.Grain, value); }
+        public int Seed { get => GetIntValue((int)EffectImpl.Properties.Seed); set => SetValue((int)EffectImpl.Properties.Seed, value); }
+        public int Style { get => GetIntValue((int)EffectImpl.Properties.Style); set => SetValue((int)EffectImpl.Properties.Style, value); }
+        public int ColorMode { get => GetIntValue((int)EffectImpl.Properties.ColorMode); set => SetValue((int)EffectImpl.Properties.ColorMode, value); }
+        public int LineLayers { get => GetIntValue((int)EffectImpl.Properties.LineLayers); set => SetValue((int)EffectImpl.Properties.LineLayers, value); }
+        public Vector4 InkColor { get => GetVector4Value((int)EffectImpl.Properties.InkColor); set => SetValue((int)EffectImpl.Properties.InkColor, value); }
+        public Vector4 PaperColor { get => GetVector4Value((int)EffectImpl.Properties.PaperColor); set => SetValue((int)EffectImpl.Properties.PaperColor, value); }
+
+        [CustomEffect(1)]
+        sealed class EffectImpl : D2D1CustomShaderEffectImplBase<EffectImpl>
+        {
+            const int SampleMargin = 2;
+
+            ConstantBuffer constants = new()
+            {
+                Amount = 1f,
+                Density = 12f,
+                Thickness = 1.2f,
+                ShadowDepth = 1f,
+                Flow = 0.4f,
+                Outline = 0.3f,
+                ToneSoftness = 0.12f,
+                Grain = 0.12f,
+                InkColor = new Vector4(17f / 255f, 17f / 255f, 17f / 255f, 1f),
+                PaperColor = new Vector4(246f / 255f, 241f / 255f, 231f / 255f, 1f),
+                Wobble = 0.25f,
+            };
+
+            [CustomEffectProperty(PropertyType.Float, (int)Properties.Amount)]
+            public float Amount { get => constants.Amount; set { constants.Amount = Clamp(value, 0f, 1f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)Properties.Density)]
+            public float Density { get => constants.Density; set { constants.Density = Clamp(value, 3f, 320f, 12f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)Properties.Thickness)]
+            public float Thickness { get => constants.Thickness; set { constants.Thickness = Clamp(value, 0.2f, 48f, 1.2f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)Properties.ShadowDepth)]
+            public float ShadowDepth { get => constants.ShadowDepth; set { constants.ShadowDepth = Clamp(value, 0f, 2f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)Properties.Flow)]
+            public float Flow { get => constants.Flow; set { constants.Flow = Clamp(value, 0f, 1f, 0.4f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)Properties.Wobble)]
+            public float Wobble { get => constants.Wobble; set { constants.Wobble = Clamp(value, 0f, 1f, 0.25f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)Properties.Outline)]
+            public float Outline { get => constants.Outline; set { constants.Outline = Clamp(value, 0f, 1f, 0.3f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)Properties.ToneSoftness)]
+            public float ToneSoftness { get => constants.ToneSoftness; set { constants.ToneSoftness = Clamp(value, 0f, 0.5f, 0.12f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)Properties.Grain)]
+            public float Grain { get => constants.Grain; set { constants.Grain = Clamp(value, 0f, 1f, 0.12f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Int32, (int)Properties.Seed)]
+            public int Seed { get => constants.Seed; set { constants.Seed = Math.Clamp(value, 0, 9999); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Int32, (int)Properties.Style)]
+            public int Style { get => constants.Style; set { constants.Style = Math.Clamp(value, 0, 3); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Int32, (int)Properties.ColorMode)]
+            public int ColorMode { get => constants.ColorMode; set { constants.ColorMode = Math.Clamp(value, 0, 1); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Int32, (int)Properties.LineLayers)]
+            public int LineLayers { get => constants.LineLayers; set { constants.LineLayers = Math.Clamp(value, 0, 4); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Vector4, (int)Properties.InkColor)]
+            public Vector4 InkColor { get => constants.InkColor; set { constants.InkColor = Saturate(value); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Vector4, (int)Properties.PaperColor)]
+            public Vector4 PaperColor { get => constants.PaperColor; set { constants.PaperColor = Saturate(value); UpdateConstants(); } }
+
+            public EffectImpl() : base(ShaderResourceUri.Get("CrossHatchShading"))
+            {
+            }
+
+            protected override void UpdateConstants()
+            {
+                drawInformation?.SetPixelShaderConstantBuffer(constants);
+            }
+
+            public override void MapInputRectsToOutputRect(RawRect[] inputRects, RawRect[] inputOpaqueSubRects, out RawRect outputRect, out RawRect outputOpaqueSubRect)
+            {
+                inputRect = inputRects.Length > 0 ? ClampInputRect(inputRects[0]) : default;
+                constants.InputBounds = new Vector4(inputRect.Left, inputRect.Top, inputRect.Right, inputRect.Bottom);
+                UpdateConstants();
+                outputRect = inputRect;
+                outputOpaqueSubRect = default;
+            }
+
+            public override void MapOutputRectToInputRects(RawRect outputRect, RawRect[] inputRects)
+            {
+                if (inputRects.Length == 0)
+                    return;
+
+                inputRects[0] = new RawRect(
+                    Saturate((long)outputRect.Left - SampleMargin),
+                    Saturate((long)outputRect.Top - SampleMargin),
+                    Saturate((long)outputRect.Right + SampleMargin),
+                    Saturate((long)outputRect.Bottom + SampleMargin));
+            }
+
+            static float Clamp(float value, float minimum, float maximum, float fallback)
+            {
+                if (!float.IsFinite(value))
+                    return fallback;
+                return Math.Clamp(value, minimum, maximum);
+            }
+
+            static Vector4 Saturate(Vector4 value) => Vector4.Clamp(value, Vector4.Zero, Vector4.One);
+
+            static int Saturate(long value) => (int)Math.Clamp(value, int.MinValue, int.MaxValue);
+
+            [StructLayout(LayoutKind.Sequential)]
+            struct ConstantBuffer
+            {
+                public float Amount;
+                public float Density;
+                public float Thickness;
+                public float ShadowDepth;
+                public float Flow;
+                public float Outline;
+                public float ToneSoftness;
+                public float Grain;
+                public int Seed;
+                public int Style;
+                public int ColorMode;
+                public int LineLayers;
+                public Vector4 InkColor;
+                public Vector4 PaperColor;
+                public Vector4 InputBounds;
+                public float Wobble;
+                public float Pad0;
+                public float Pad1;
+                public float Pad2;
+            }
+
+            public enum Properties
+            {
+                Amount,
+                Density,
+                Thickness,
+                ShadowDepth,
+                Flow,
+                Wobble,
+                Outline,
+                ToneSoftness,
+                Grain,
+                Seed,
+                Style,
+                ColorMode,
+                LineLayers,
+                InkColor,
+                PaperColor,
+            }
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/CrossHatchShadingEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/CrossHatchShadingEffect.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Windows.Media;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossHatchShading
+{
+    [VideoEffect(nameof(Texts.CrossHatchShadingEffectName), [VideoEffectCategories.Filtering], [nameof(Texts.TagCrossHatch), nameof(Texts.TagHatching), nameof(Texts.TagPen), nameof(Texts.TagEngraving), nameof(Texts.TagBlueprint), nameof(Texts.TagManga)], IsAviUtlSupported = false, ResourceType = typeof(Texts))]
+    public sealed class CrossHatchShadingEffect : VideoEffectBase
+    {
+        public override string Label => Texts.CrossHatchShadingEffectName;
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingBasicGroup), Name = nameof(Texts.CrossHatchShadingStyleName), Description = nameof(Texts.CrossHatchShadingStyleDesc), Order = 0, ResourceType = typeof(Texts))]
+        [EnumComboBox]
+        public CrossHatchStyle Style { get => style; set => Set(ref style, value); }
+        CrossHatchStyle style = CrossHatchStyle.Pen;
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingBasicGroup), Name = nameof(Texts.CrossHatchShadingAmountName), Description = nameof(Texts.CrossHatchShadingAmountDesc), Order = 10, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0d, 100d)]
+        public Animation Amount { get; } = new(100, 0, 100);
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingBasicGroup), Name = nameof(Texts.CrossHatchShadingDensityName), Description = nameof(Texts.CrossHatchShadingDensityDesc), Order = 20, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", 3d, 80d)]
+        public Animation Density { get; } = new(12, 3, 320);
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingBasicGroup), Name = nameof(Texts.CrossHatchShadingThicknessName), Description = nameof(Texts.CrossHatchShadingThicknessDesc), Order = 30, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", 0.2d, 12d)]
+        public Animation Thickness { get; } = new(1.2, 0.2, 48);
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingBasicGroup), Name = nameof(Texts.CrossHatchShadingShadowDepthName), Description = nameof(Texts.CrossHatchShadingShadowDepthDesc), Order = 40, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0d, 200d)]
+        public Animation ShadowDepth { get; } = new(100, 0, 200);
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingBasicGroup), Name = nameof(Texts.CrossHatchShadingFlowName), Description = nameof(Texts.CrossHatchShadingFlowDesc), Order = 50, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0d, 100d)]
+        public Animation Flow { get; } = new(40, 0, 100);
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingBasicGroup), Name = nameof(Texts.CrossHatchShadingWobbleName), Description = nameof(Texts.CrossHatchShadingWobbleDesc), Order = 55, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0d, 100d)]
+        public Animation Wobble { get; } = new(25, 0, 100);
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingBasicGroup), Name = nameof(Texts.CrossHatchShadingOutlineName), Description = nameof(Texts.CrossHatchShadingOutlineDesc), Order = 60, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0d, 100d)]
+        public Animation Outline { get; } = new(30, 0, 100);
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingColorGroup), Name = nameof(Texts.CrossHatchShadingInkColorName), Description = nameof(Texts.CrossHatchShadingInkColorDesc), Order = 100, ResourceType = typeof(Texts))]
+        [ColorPicker]
+        public Color InkColor { get => inkColor; set => Set(ref inkColor, value); }
+        Color inkColor = Color.FromArgb(255, 17, 17, 17);
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingColorGroup), Name = nameof(Texts.CrossHatchShadingPaperColorName), Description = nameof(Texts.CrossHatchShadingPaperColorDesc), Order = 110, ResourceType = typeof(Texts))]
+        [ColorPicker]
+        public Color PaperColor { get => paperColor; set => Set(ref paperColor, value); }
+        Color paperColor = Color.FromArgb(255, 246, 241, 231);
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingColorGroup), Name = nameof(Texts.CrossHatchShadingColorModeName), Description = nameof(Texts.CrossHatchShadingColorModeDesc), Order = 120, ResourceType = typeof(Texts))]
+        [EnumComboBox]
+        public CrossHatchColorMode ColorMode { get => colorMode; set => Set(ref colorMode, value); }
+        CrossHatchColorMode colorMode = CrossHatchColorMode.InkAndPaper;
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingDetailGroup), Name = nameof(Texts.CrossHatchShadingLineLayersName), Description = nameof(Texts.CrossHatchShadingLineLayersDesc), Order = 200, ResourceType = typeof(Texts))]
+        [EnumComboBox]
+        public CrossHatchLineLayers LineLayers { get => lineLayers; set => Set(ref lineLayers, value); }
+        CrossHatchLineLayers lineLayers = CrossHatchLineLayers.Auto;
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingDetailGroup), Name = nameof(Texts.CrossHatchShadingToneSoftnessName), Description = nameof(Texts.CrossHatchShadingToneSoftnessDesc), Order = 210, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0d, 50d)]
+        public Animation ToneSoftness { get; } = new(12, 0, 50);
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingDetailGroup), Name = nameof(Texts.CrossHatchShadingGrainName), Description = nameof(Texts.CrossHatchShadingGrainDesc), Order = 220, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0d, 100d)]
+        public Animation Grain { get; } = new(12, 0, 100);
+
+        [Display(GroupName = nameof(Texts.CrossHatchShadingDetailGroup), Name = nameof(Texts.CrossHatchShadingSeedName), Description = nameof(Texts.CrossHatchShadingSeedDesc), Order = 230, ResourceType = typeof(Texts))]
+        [Range(0, 9999)]
+        [DefaultValue(0)]
+        [TextBoxSlider("F0", "", 0, 9999)]
+        public int Seed { get => seed; set => Set(ref seed, Math.Clamp(value, 0, 9999)); }
+        int seed;
+
+        public override IEnumerable<string> CreateExoVideoFilters(int keyFrameIndex, ExoOutputDescription exoOutputDescription) => [];
+
+        public override IVideoEffectProcessor CreateVideoEffect(IGraphicsDevicesAndContext devices) => new CrossHatchShadingEffectProcessor(devices, this);
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() => [Amount, Density, Thickness, ShadowDepth, Flow, Wobble, Outline, ToneSoftness, Grain];
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/CrossHatchShadingEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/CrossHatchShadingEffectProcessor.cs
@@ -1,0 +1,112 @@
+using System.Numerics;
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Player.Video.Effects;
+using static YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossHatchShading.ParameterNormalizer;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossHatchShading
+{
+    internal sealed class CrossHatchShadingEffectProcessor(IGraphicsDevicesAndContext devices, CrossHatchShadingEffect item) : VideoEffectProcessorBase(devices)
+    {
+        readonly CrossHatchShadingEffect item = item;
+        CrossHatchShadingCustomEffect? effect;
+        Parameters parameters;
+        bool isFirst = true;
+
+        public override DrawDescription Update(EffectDescription effectDescription)
+        {
+            if (IsPassThroughEffect || effect is null)
+                return effectDescription.DrawDescription;
+
+            var frame = effectDescription.ItemPosition.Frame;
+            var length = effectDescription.ItemDuration.Frame;
+            var fps = effectDescription.FPS;
+            var next = new Parameters(
+                Percent(item.Amount.GetValue(frame, length, fps), 0f, 1f, 1f),
+                Finite(item.Density.GetValue(frame, length, fps), 3f, 320f, 12f),
+                Finite(item.Thickness.GetValue(frame, length, fps), 0.2f, 48f, 1.2f),
+                Percent(item.ShadowDepth.GetValue(frame, length, fps), 0f, 2f, 1f),
+                Percent(item.Flow.GetValue(frame, length, fps), 0f, 1f, 0.4f),
+                Percent(item.Wobble.GetValue(frame, length, fps), 0f, 1f, 0.25f),
+                Percent(item.Outline.GetValue(frame, length, fps), 0f, 1f, 0.3f),
+                Percent(item.ToneSoftness.GetValue(frame, length, fps), 0f, 0.5f, 0.12f),
+                Percent(item.Grain.GetValue(frame, length, fps), 0f, 1f, 0.12f),
+                Math.Clamp(item.Seed, 0, 9999),
+                (int)item.Style,
+                (int)item.ColorMode,
+                (int)item.LineLayers,
+                ToVector(item.InkColor),
+                ToVector(item.PaperColor));
+
+            if (isFirst || parameters != next)
+            {
+                effect.Amount = next.Amount;
+                effect.Density = next.Density;
+                effect.Thickness = next.Thickness;
+                effect.ShadowDepth = next.ShadowDepth;
+                effect.Flow = next.Flow;
+                effect.Wobble = next.Wobble;
+                effect.Outline = next.Outline;
+                effect.ToneSoftness = next.ToneSoftness;
+                effect.Grain = next.Grain;
+                effect.Seed = next.Seed;
+                effect.Style = next.Style;
+                effect.ColorMode = next.ColorMode;
+                effect.LineLayers = next.LineLayers;
+                effect.InkColor = next.InkColor;
+                effect.PaperColor = next.PaperColor;
+                parameters = next;
+                isFirst = false;
+            }
+
+            return effectDescription.DrawDescription;
+        }
+
+        static Vector4 ToVector(System.Windows.Media.Color color) => new(color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f);
+
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            effect = new CrossHatchShadingCustomEffect(devices);
+            if (!effect.IsEnabled)
+            {
+                effect.Dispose();
+                effect = null;
+                return null;
+            }
+
+            disposer.Collect(effect);
+            var output = effect.Output;
+            disposer.Collect(output);
+            return output;
+        }
+
+        protected override void setInput(ID2D1Image? input)
+        {
+            effect?.SetInput(0, input, true);
+        }
+
+        protected override void ClearEffectChain()
+        {
+            effect?.SetInput(0, null, true);
+            isFirst = true;
+        }
+
+        readonly record struct Parameters(
+            float Amount,
+            float Density,
+            float Thickness,
+            float ShadowDepth,
+            float Flow,
+            float Wobble,
+            float Outline,
+            float ToneSoftness,
+            float Grain,
+            int Seed,
+            int Style,
+            int ColorMode,
+            int LineLayers,
+            Vector4 InkColor,
+            Vector4 PaperColor);
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/CrossHatchStyle.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/CrossHatchStyle.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossHatchShading
+{
+    public enum CrossHatchStyle
+    {
+        [Display(Name = nameof(Texts.CrossHatchShadingStylePen), Description = nameof(Texts.CrossHatchShadingStylePenDesc), ResourceType = typeof(Texts))]
+        Pen = 0,
+
+        [Display(Name = nameof(Texts.CrossHatchShadingStyleEngraving), Description = nameof(Texts.CrossHatchShadingStyleEngravingDesc), ResourceType = typeof(Texts))]
+        Engraving = 1,
+
+        [Display(Name = nameof(Texts.CrossHatchShadingStyleManga), Description = nameof(Texts.CrossHatchShadingStyleMangaDesc), ResourceType = typeof(Texts))]
+        Manga = 2,
+
+        [Display(Name = nameof(Texts.CrossHatchShadingStyleBlueprint), Description = nameof(Texts.CrossHatchShadingStyleBlueprintDesc), ResourceType = typeof(Texts))]
+        Blueprint = 3,
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/ParameterNormalizer.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/ParameterNormalizer.cs
@@ -1,0 +1,14 @@
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossHatchShading
+{
+    internal static class ParameterNormalizer
+    {
+        public static float Percent(double value, float minimum, float maximum, float fallback) => Finite(value / 100d, minimum, maximum, fallback);
+
+        public static float Finite(double value, float minimum, float maximum, float fallback)
+        {
+            if (!double.IsFinite(value))
+                return fallback;
+            return (float)Math.Clamp(value, minimum, maximum);
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/Texts.cs
@@ -1,0 +1,9 @@
+using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossHatchShading
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/Texts.csv
@@ -4,7 +4,7 @@ CrossHatchShadingBasicGroup,,基本,Basic,基本,基本,기본,Básico,أساس�
 CrossHatchShadingColorGroup,,色,Color,颜色,顏色,색상,Color,اللون,Warna
 CrossHatchShadingDetailGroup,,詳細,Detail,详细,詳細,상세,Detalle,تفاصيل,Detail
 CrossHatchShadingStyleName,,スタイル,Style,样式,樣式,스타일,Estilo,النمط,Gaya
-CrossHatchShadingStyleDesc,,線の方向と階調と質感のプリセットを選びます。,Selects a preset of line direction tone and texture.,选择线条方向、色调与质感的预设。,選擇線條方向、色調與質感的預設。,선 방향과 계조와 질감의 프리셋을 선택합니다.,Selecciona un preset de dirección tono y textura de línea.,يختار إعدادًا مسبقًا لاتجاه الخط ودرجته وملمسه.,Memilih preset arah nada dan tekstur garis.
+CrossHatchShadingStyleDesc,,線の方向と階調と質感のプリセットを選びます。,"Selects a preset for line direction, tone, and texture.",选择线条方向、色调与质感的预设。,選擇線條方向、色調與質感的預設。,선 방향과 계조와 질감의 프리셋을 선택합니다.,Selecciona un preset de dirección tono y textura de línea.,يختار إعدادًا مسبقًا لاتجاه الخط ودرجته وملمسه.,Memilih preset arah nada dan tekstur garis.
 CrossHatchShadingAmountName,,適用量,Amount,应用量,套用量,적용량,Cantidad,المقدار,Jumlah
 CrossHatchShadingAmountDesc,,元映像とハッチ結果の合成量です。,Blends between the source and the hatched result.,混合原始画面与排线结果。,混合原始畫面與排線結果。,원본과 해칭 결과를 혼합합니다.,Mezcla entre el origen y el resultado de trama.,يمزج بين المصدر ونتيجة التظليل.,Mencampur sumber dengan hasil arsir.
 CrossHatchShadingDensityName,,密度,Density,密度,密度,밀도,Densidad,الكثافة,Kerapatan

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossHatchShading/Texts.csv
@@ -1,0 +1,58 @@
+Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+CrossHatchShadingEffectName,,クロスハッチ陰影,Cross Hatch Shading,交叉排线阴影,交叉排線陰影,크로스해치 음영,Sombreado de trama cruzada,تظليل بالخطوط المتقاطعة,Bayangan Arsir Silang
+CrossHatchShadingBasicGroup,,基本,Basic,基本,基本,기본,Básico,أساسي,Dasar
+CrossHatchShadingColorGroup,,色,Color,颜色,顏色,색상,Color,اللون,Warna
+CrossHatchShadingDetailGroup,,詳細,Detail,详细,詳細,상세,Detalle,تفاصيل,Detail
+CrossHatchShadingStyleName,,スタイル,Style,样式,樣式,스타일,Estilo,النمط,Gaya
+CrossHatchShadingStyleDesc,,線の方向と階調と質感のプリセットを選びます。,Selects a preset of line direction tone and texture.,选择线条方向、色调与质感的预设。,選擇線條方向、色調與質感的預設。,선 방향과 계조와 질감의 프리셋을 선택합니다.,Selecciona un preset de dirección tono y textura de línea.,يختار إعدادًا مسبقًا لاتجاه الخط ودرجته وملمسه.,Memilih preset arah nada dan tekstur garis.
+CrossHatchShadingAmountName,,適用量,Amount,应用量,套用量,적용량,Cantidad,المقدار,Jumlah
+CrossHatchShadingAmountDesc,,元映像とハッチ結果の合成量です。,Blends between the source and the hatched result.,混合原始画面与排线结果。,混合原始畫面與排線結果。,원본과 해칭 결과를 혼합합니다.,Mezcla entre el origen y el resultado de trama.,يمزج بين المصدر ونتيجة التظليل.,Mencampur sumber dengan hasil arsir.
+CrossHatchShadingDensityName,,密度,Density,密度,密度,밀도,Densidad,الكثافة,Kerapatan
+CrossHatchShadingDensityDesc,,線の間隔です。小さいほど線が密になります。,Spacing between lines. Smaller values pack lines tighter.,线条间隔。数值越小线条越密。,線條間隔。數值越小線條越密。,선 간격입니다. 값이 작을수록 선이 촘촘해집니다.,Espacio entre líneas. Valores menores las juntan más.,المسافة بين الخطوط. القيم الأصغر تقارب الخطوط.,Jarak antar garis. Nilai kecil merapatkan garis.
+CrossHatchShadingThicknessName,,太さ,Thickness,粗细,粗細,굵기,Grosor,السماكة,Ketebalan
+CrossHatchShadingThicknessDesc,,各ハッチ線の太さです。,Width of each hatch line.,每条排线的宽度。,每條排線的寬度。,각 해칭 선의 너비입니다.,Ancho de cada línea de trama.,عرض كل خط تظليل.,Lebar tiap garis arsir.
+CrossHatchShadingShadowDepthName,,陰影,Shadow,阴影,陰影,음영,Sombra,الظل,Bayangan
+CrossHatchShadingShadowDepthDesc,,暗部で線が増える強さです。,How strongly lines build up in dark areas.,暗部中线条增加的强度。,暗部中線條增加的強度。,어두운 영역에서 선이 늘어나는 강도입니다.,Cuánto se acumulan las líneas en zonas oscuras.,مدى تكاثف الخطوط في المناطق الداكنة.,Seberapa kuat garis menumpuk di area gelap.
+CrossHatchShadingFlowName,,流れ,Flow,流向,流向,흐름,Flujo,التدفق,Aliran
+CrossHatchShadingFlowDesc,,明暗の勾配へ線の向きを寄せる強さです。,How strongly line direction follows the luminance gradient.,线条方向顺应明暗梯度的强度。,線條方向順應明暗梯度的強度。,선 방향이 명암 기울기를 따르는 강도입니다.,Cuánto sigue la dirección de línea al gradiente de luz.,مدى اتباع اتجاه الخط لميل الإضاءة.,Seberapa kuat arah garis mengikuti gradien terang.
+CrossHatchShadingWobbleName,,手描き揺らぎ,Wobble,手绘抖动,手繪抖動,손그림 흔들림,Temblor,اهتزاز يدوي,Goyangan
+CrossHatchShadingWobbleDesc,,線の位置と太さを揺らして手描きの質感を加えます。,Perturbs line position and width for a hand-drawn feel.,抖动线条位置与粗细以增加手绘质感。,抖動線條位置與粗細以增加手繪質感。,선의 위치와 굵기를 흔들어 손그림 질감을 더합니다.,Perturba la posición y el grosor de las líneas para un aspecto dibujado a mano.,يهزّ موضع الخطوط وسمكها لإضفاء ملمس مرسوم يدويًا.,Menggoyangkan posisi dan ketebalan garis untuk kesan gambar tangan.
+CrossHatchShadingOutlineName,,輪郭,Outline,轮廓,輪廓,윤곽,Contorno,المخطط,Garis Tepi
+CrossHatchShadingOutlineDesc,,ハッチに重ねる輪郭線の強さです。,Strength of the contour lines added over the hatching.,叠加在排线上的轮廓线强度。,疊加在排線上的輪廓線強度。,해칭 위에 더해지는 윤곽선 강도입니다.,Intensidad de los contornos sobre la trama.,قوة خطوط الكفاف فوق التظليل.,Kekuatan garis kontur di atas arsiran.
+CrossHatchShadingInkColorName,,インク色,Ink Color,墨色,墨色,잉크 색,Color de tinta,لون الحبر,Warna Tinta
+CrossHatchShadingInkColorDesc,,ハッチ線と輪郭線の色です。,Color of the hatch and contour lines.,排线与轮廓线的颜色。,排線與輪廓線的顏色。,해칭과 윤곽선의 색입니다.,Color de las líneas de trama y contorno.,لون خطوط التظليل والكفاف.,Warna garis arsir dan kontur.
+CrossHatchShadingPaperColorName,,紙色,Paper Color,纸色,紙色,종이 색,Color de papel,لون الورق,Warna Kertas
+CrossHatchShadingPaperColorDesc,,紙または背景の色です。,Color of the paper or background.,纸张或背景的颜色。,紙張或背景的顏色。,종이 또는 배경의 색입니다.,Color del papel o fondo.,لون الورق أو الخلفية.,Warna kertas atau latar.
+CrossHatchShadingColorModeName,,色,Color,颜色,顏色,색상,Color,اللون,Warna
+CrossHatchShadingColorModeDesc,,出力色の作り方です。,How the output color is composed.,输出颜色的生成方式。,輸出顏色的生成方式。,출력 색을 만드는 방식입니다.,Cómo se compone el color de salida.,طريقة تكوين لون الإخراج.,Cara warna keluaran disusun.
+CrossHatchShadingLineLayersName,,線の層,Line Layers,线层,線層,선 레이어,Capas de línea,طبقات الخطوط,Lapis Garis
+CrossHatchShadingLineLayersDesc,,暗部に重ねる線方向の最大数です。,Maximum number of line directions stacked in shadows.,暗部叠加的线条方向最大数量。,暗部疊加的線條方向最大數量。,어두운 부분에 겹치는 선 방향의 최대 수입니다.,Número máximo de direcciones de línea en sombra.,أقصى عدد لاتجاهات الخطوط في الظل.,Jumlah maksimum arah garis pada bayangan.
+CrossHatchShadingToneSoftnessName,,階調の柔らかさ,Tone Softness,色调柔和度,色調柔和度,계조 부드러움,Suavidad de tono,نعومة التدرج,Kelembutan Nada
+CrossHatchShadingToneSoftnessDesc,,線層が現れる境界の柔らかさです。,Softness of the boundary where a line layer appears.,线层出现边界的柔和程度。,線層出現邊界的柔和程度。,선 레이어가 나타나는 경계의 부드러움입니다.,Suavidad del borde donde aparece una capa.,نعومة الحد الذي تظهر عنده طبقة الخط.,Kelembutan batas tempat lapis garis muncul.
+CrossHatchShadingGrainName,,粒状感,Grain,颗粒感,顆粒感,입자감,Grano,الحبيبات,Butiran
+CrossHatchShadingGrainDesc,,紙とインクの手続き的な粒状感です。,Procedural grain of the paper and ink.,纸张与墨水的程序化颗粒。,紙張與墨水的程序化顆粒。,종이와 잉크의 절차적 입자입니다.,Grano procedural del papel y la tinta.,حبيبات إجرائية للورق والحبر.,Butiran prosedural kertas dan tinta.
+CrossHatchShadingSeedName,,シード,Seed,种子,種子,시드,Semilla,البذرة,Seed
+CrossHatchShadingSeedDesc,,粒状感と線位相を固定する値です。,Fixed value for grain and line phase.,固定颗粒与线条相位的数值。,固定顆粒與線條相位的數值。,입자와 선 위상을 고정하는 값입니다.,Valor fijo para el grano y la fase de línea.,قيمة ثابتة للحبيبات وطور الخط.,Nilai tetap untuk butiran dan fase garis.
+CrossHatchShadingStylePen,,ペン画,Pen,钢笔,鋼筆,펜,Pluma,قلم,Pena
+CrossHatchShadingStylePenDesc,,ペン画やイラスト向けの細い線です。,Fine lines for pen drawing and illustration.,适合钢笔画与插画的细线。,適合鋼筆畫與插畫的細線。,펜화와 일러스트용 가는 선입니다.,Líneas finas para dibujo a pluma e ilustración.,خطوط رفيعة للرسم بالقلم والتوضيح.,Garis halus untuk gambar pena dan ilustrasi.
+CrossHatchShadingStyleEngraving,,版画,Engraving,版画,版畫,판화,Grabado,نقش,Ukiran
+CrossHatchShadingStyleEngravingDesc,,版画や紙幣風の斜め線です。,Slanted lines for engraving and banknote looks.,版画与纸币风格的斜线。,版畫與紙幣風格的斜線。,판화와 지폐풍 사선입니다.,Líneas inclinadas estilo grabado y billete.,خطوط مائلة بأسلوب النقش والأوراق النقدية.,Garis miring gaya ukiran dan uang kertas.
+CrossHatchShadingStyleManga,,漫画,Manga,漫画,漫畫,만화,Manga,مانغا,Manga
+CrossHatchShadingStyleMangaDesc,,漫画背景向けの陰影トーンです。,Shading tone for manga backgrounds.,适合漫画背景的阴影网点。,適合漫畫背景的陰影網點。,만화 배경용 음영 톤입니다.,Tono de sombreado para fondos de manga.,درجة تظليل لخلفيات المانغا.,Nada bayangan untuk latar manga.
+CrossHatchShadingStyleBlueprint,,設計図,Blueprint,蓝图,藍圖,청사진,Plano,مخطط أزرق,Cetak Biru
+CrossHatchShadingStyleBlueprintDesc,,設計図や技術資料風の直交線です。,Orthogonal lines for technical drawings.,设计图与技术资料风格的正交线。,設計圖與技術資料風格的正交線。,설계도와 기술 자료풍 직교선입니다.,Líneas ortogonales para dibujos técnicos.,خطوط متعامدة للرسومات التقنية.,Garis ortogonal untuk gambar teknik.
+CrossHatchShadingColorModeInkAndPaper,,インクと紙,Ink and Paper,墨与纸,墨與紙,잉크와 종이,Tinta y papel,الحبر والورق,Tinta dan Kertas
+CrossHatchShadingColorModeInkAndPaperDesc,,紙色とインク色だけで描きます。,Draws using only paper and ink colors.,仅用纸色与墨色绘制。,僅用紙色與墨色繪製。,종이색과 잉크색만으로 그립니다.,Dibuja solo con colores de papel y tinta.,يرسم بلوني الورق والحبر فقط.,Menggambar hanya dengan warna kertas dan tinta.
+CrossHatchShadingColorModePreserveSource,,元の色を残す,Preserve Source,保留原色,保留原色,원본 색 유지,Conservar origen,الحفاظ على المصدر,Pertahankan Sumber
+CrossHatchShadingColorModePreserveSourceDesc,,元映像の色を残してインク線を重ねます。,Keeps the source color and overlays ink lines.,保留原始颜色并叠加墨线。,保留原始顏色並疊加墨線。,원본 색을 남기고 잉크선을 덧그립니다.,Conserva el color original y superpone tinta.,يبقي اللون الأصلي ويضيف خطوط الحبر.,Menjaga warna asli dan menimpa garis tinta.
+CrossHatchShadingLineLayersAuto,,自動,Auto,自动,自動,자동,Automático,تلقائي,Otomatis
+CrossHatchShadingLineLayers1,,1,1,1,1,1,1,1,1
+CrossHatchShadingLineLayers2,,2,2,2,2,2,2,2,2
+CrossHatchShadingLineLayers3,,3,3,3,3,3,3,3,3
+CrossHatchShadingLineLayers4,,4,4,4,4,4,4,4,4
+TagCrossHatch,,クロスハッチ,cross hatch,交叉排线,交叉排線,크로스해치,trama cruzada,تظليل متقاطع,arsir silang
+TagHatching,,ハッチング,hatching,排线,排線,해칭,trama,تظليل,arsir
+TagPen,,ペン画,pen drawing,钢笔画,鋼筆畫,펜화,dibujo a pluma,رسم بالقلم,gambar pena
+TagEngraving,,版画,engraving,版画,版畫,판화,grabado,نقش,ukiran
+TagBlueprint,,設計図,blueprint,蓝图,藍圖,청사진,plano,مخطط أزرق,cetak biru
+TagManga,,漫画,manga,漫画,漫畫,만화,manga,مانغا,manga

--- a/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
+++ b/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
@@ -173,6 +173,7 @@
 	  <Resource Include="$(ShaderDirPath)AnisotropicKuwaharaTensor.cso" Link="Resources\Shader\AnisotropicKuwaharaTensor.cso" />
 	  <Resource Include="$(ShaderDirPath)AnisotropicKuwaharaTensorBlur.cso" Link="Resources\Shader\AnisotropicKuwaharaTensorBlur.cso" />
 	  <Resource Include="$(ShaderDirPath)AnisotropicKuwahara.cso" Link="Resources\Shader\AnisotropicKuwahara.cso" />
+	  <Resource Include="$(ShaderDirPath)CrossHatchShading.cso" Link="Resources\Shader\CrossHatchShading.cso" />
   </ItemGroup>
 
   <!-- internalsを参照するテスト（EdgeDetectionZeroStrengthOverlayTest等）はDEBUG限定のため、Releaseビルドには付与しない -->


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [x] このPRには1つの機能（または1つの修正）のみが含まれています
- [x] `YukkuriMovieMaker.dll`などYMM4本体の内部実装アセンブリを参照していません

## 概要
<!-- 変更内容を簡単に記載してください -->
新しい映像エフェクト「クロスハッチ陰影」を追加します。
映像の明暗からハッチングを生成し、ペン画や版画のような手描き調の陰影に変換するエフェクトです。暗い部分ほど線の層が重なって濃くなり、輪郭線と紙・インクの質感もあわせて表現できます。

## エフェクト本体
輝度から陰影量を求め、最大4方向の線層を階調のしきい値に応じて重ねます。線の密度、太さ、陰影の強さ、階調境界の柔らかさをそれぞれ調整でき、シード値で線の位相と粒状感を固定できます。シード値を除く数値パラメータはすべてアニメーションに対応しています。シード値は線の位相と粒状感を固定するための値のため、ちらつき防止の観点から固定値としています。
スタイルとして「ペン画」「版画」「漫画」「設計図」の4プリセットを用意し、線の角度、階調しきい値、輪郭・粒状感の効き方を切り替えます。色は「インクと紙」と「元の色を残す」の2モードです。
D2Dカスタムエフェクトのピクセルシェーダーとして実装しています。輝度勾配はScharrフィルタで求め、その接線方向へ線の向きを寄せる「流れ」パラメータにより、形状に沿ったハッチングを表現できます。輪郭線は輝度勾配とアルファ勾配の合成から検出するため、透過素材の縁にも線が乗ります。出力矩形は入力と同一で、サンプリングは入力境界内にクランプしています。