### PR TITLE
映像エフェクト「多面体ガラス」を追加

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community.Shader/FacetedGlass.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/FacetedGlass.hlsl
@@ -1,0 +1,208 @@
+Texture2D SourceTexture : register(t0);
+SamplerState SourceSampler : register(s0);
+
+cbuffer Constants : register(b0)
+{
+    float4 inputBounds : packoffset(c0);
+    float amount : packoffset(c1.x);
+    float cellSize : packoffset(c1.y);
+    float irregularity : packoffset(c1.z);
+    float relief : packoffset(c1.w);
+    float rotation : packoffset(c2.x);
+    float evolution : packoffset(c2.y);
+    float refraction : packoffset(c2.z);
+    float refractiveIndex : packoffset(c2.w);
+    float dispersion : packoffset(c3.x);
+    float reflection : packoffset(c3.y);
+    float glint : packoffset(c3.z);
+    float borderWidth : packoffset(c3.w);
+    float lightAngle : packoffset(c4.x);
+    float lightElevation : packoffset(c4.y);
+    int seed : packoffset(c4.z);
+};
+
+static const float Sqrt3 = 1.7320508075688772;
+static const float TwoPi = 6.283185307179586;
+static const float WavelengthF = 486.1;
+static const float WavelengthD = 587.6;
+static const float WavelengthC = 656.3;
+
+uint Hash32(uint value)
+{
+    value ^= value >> 16;
+    value *= 0x7feb352du;
+    value ^= value >> 15;
+    value *= 0x846ca68bu;
+    value ^= value >> 16;
+    return value;
+}
+
+float CellHash(int2 cell, uint channel)
+{
+    uint value = asuint(cell.x) * 0x9e3779b9u;
+    value ^= asuint(cell.y) * 0x85ebca6bu;
+    value ^= asuint(seed) * 0xc2b2ae35u;
+    value ^= channel * 0x27d4eb2fu;
+    return Hash32(value) / 4294967295.0;
+}
+
+float2 Rotate(float2 coordinate, float angle)
+{
+    float cosine = cos(angle);
+    float sine = sin(angle);
+    return float2(coordinate.x * cosine - coordinate.y * sine, coordinate.x * sine + coordinate.y * cosine);
+}
+
+float2 SitePoint(int2 cell)
+{
+    float2 lattice = float2(cell.x + 0.5 * cell.y, 0.5 * Sqrt3 * cell.y) * cellSize;
+    float radius = 0.45 * cellSize * irregularity * CellHash(cell, 0u);
+    float angle = TwoPi * CellHash(cell, 1u);
+    return lattice + radius * float2(cos(angle), sin(angle));
+}
+
+float3 FacetNormal(int2 cell)
+{
+    float azimuth = TwoPi * CellHash(cell, 2u) + evolution * (0.35 + 0.65 * CellHash(cell, 3u));
+    float breathing = 0.6 + 0.4 * sin(evolution + TwoPi * CellHash(cell, 4u));
+    float tilt = relief * 0.5 * breathing * (0.4 + 0.6 * CellHash(cell, 5u));
+    float sine = sin(tilt);
+    return float3(sine * cos(azimuth), sine * sin(azimuth), cos(tilt));
+}
+
+float CauchyIndex(float wavelength)
+{
+    float deltaFC = 0.04 * dispersion;
+    float denominator = 1.0 / (WavelengthF * WavelengthF) - 1.0 / (WavelengthC * WavelengthC);
+    float b = deltaFC / denominator;
+    float a = refractiveIndex - b / (WavelengthD * WavelengthD);
+    return a + b / (wavelength * wavelength);
+}
+
+float2 RefractionOffset(float3 normal, float index)
+{
+    float3 direction = refract(float3(0.0, 0.0, -1.0), normal, 1.0 / max(index, 1.0001));
+    return direction.xy / max(abs(direction.z), 1e-4) * refraction;
+}
+
+float4 SampleAt(float2 uv, float2 pixelStep, float2 scenePosition, float2 offset)
+{
+    float2 minimum = inputBounds.xy + 0.5;
+    float2 maximum = inputBounds.zw - 0.5;
+    float2 target = clamp(scenePosition + offset, minimum, maximum);
+    return SourceTexture.SampleLevel(SourceSampler, uv + (target - scenePosition) * pixelStep, 0);
+}
+
+float3 StraightColor(float4 sample, float3 fallback)
+{
+    if (sample.a <= 1e-5)
+        return fallback;
+    return sample.rgb / sample.a;
+}
+
+float Schlick(float index, float cosine)
+{
+    float f0 = (index - 1.0) / (index + 1.0);
+    f0 *= f0;
+    return f0 + (1.0 - f0) * pow(1.0 - saturate(cosine), 5.0);
+}
+
+float4 main(
+    float4 position : SV_POSITION,
+    float4 scenePosition : SCENE_POSITION,
+    float4 uv0 : TEXCOORD0
+) : SV_TARGET
+{
+    float4 source = SourceTexture.SampleLevel(SourceSampler, uv0.xy, 0);
+    if (amount <= 0.0 || source.a <= 0.0)
+        return source;
+
+    float2 center = 0.5 * (inputBounds.xy + inputBounds.zw);
+    float rotationRadians = radians(rotation);
+    float2 local = Rotate(scenePosition.xy - center, -rotationRadians);
+    float latticeV = 2.0 * local.y / (Sqrt3 * cellSize);
+    float latticeU = local.x / cellSize - 0.5 * latticeV;
+    int2 baseCell = int2(floor(latticeU + 0.5), floor(latticeV + 0.5));
+
+    int2 bestCell = baseCell;
+    float2 bestPoint = SitePoint(baseCell);
+    float bestDistance = dot(local - bestPoint, local - bestPoint);
+
+    [loop]
+    for (int du = -2; du <= 2; du++)
+    {
+        [loop]
+        for (int dv = -2; dv <= 2; dv++)
+        {
+            int2 cell = baseCell + int2(du, dv);
+            float2 site = SitePoint(cell);
+            float2 delta = local - site;
+            float distance = dot(delta, delta);
+            if (distance < bestDistance)
+            {
+                bestDistance = distance;
+                bestCell = cell;
+                bestPoint = site;
+            }
+        }
+    }
+
+    float edgeDistance = 1e8;
+
+    [loop]
+    for (int eu = -2; eu <= 2; eu++)
+    {
+        [loop]
+        for (int ev = -2; ev <= 2; ev++)
+        {
+            int2 cell = bestCell + int2(eu, ev);
+            if (all(cell == bestCell))
+                continue;
+            float2 site = SitePoint(cell);
+            float2 toSite = site - bestPoint;
+            float lengthToSite = length(toSite);
+            if (lengthToSite < 1e-4)
+                continue;
+            float distance = dot(local - 0.5 * (bestPoint + site), toSite / lengthToSite);
+            edgeDistance = min(edgeDistance, abs(distance));
+        }
+    }
+
+    float3 normal = FacetNormal(bestCell);
+    normal.xy = Rotate(normal.xy, rotationRadians);
+
+    float indexR = CauchyIndex(610.0);
+    float indexG = CauchyIndex(550.0);
+    float indexB = CauchyIndex(460.0);
+    float3 sourceStraight = source.rgb / max(source.a, 1e-5);
+    float4 sampleR = SampleAt(uv0.xy, uv0.zw, scenePosition.xy, RefractionOffset(normal, indexR));
+    float4 sampleG = SampleAt(uv0.xy, uv0.zw, scenePosition.xy, RefractionOffset(normal, indexG));
+    float4 sampleB = SampleAt(uv0.xy, uv0.zw, scenePosition.xy, RefractionOffset(normal, indexB));
+    float3 refracted = float3(
+        StraightColor(sampleR, sourceStraight).r,
+        StraightColor(sampleG, sourceStraight).g,
+        StraightColor(sampleB, sourceStraight).b);
+
+    float angleRadians = radians(lightAngle);
+    float elevationRadians = radians(lightElevation);
+    float cosineElevation = cos(elevationRadians);
+    float3 light = normalize(float3(cos(angleRadians) * cosineElevation, sin(angleRadians) * cosineElevation, sin(elevationRadians)));
+    float3 view = float3(0.0, 0.0, 1.0);
+    float diffuse = 0.78 + 0.22 * saturate(dot(normal, light));
+    float fresnel = Schlick(indexG, dot(normal, view));
+    float mirrored = saturate(dot(reflect(-light, normal), view));
+    float specular = pow(mirrored, 48.0);
+    float flicker = 0.5 + 0.5 * sin(evolution * 1.7 + TwoPi * CellHash(bestCell, 6u));
+    float sparkle = glint * pow(mirrored, 160.0) * (0.35 + 0.65 * flicker);
+
+    float antialias = max(fwidth(edgeDistance), 0.5);
+    float border = borderWidth <= 0.0 ? 0.0 : 1.0 - smoothstep(borderWidth, borderWidth + antialias, edgeDistance);
+
+    float reflectance = reflection * (fresnel + specular * 0.75 + border * 0.35) + sparkle;
+    float3 glass = refracted * diffuse * (1.0 - saturate(fresnel * reflection * 0.35));
+    glass += reflectance.xxx;
+    glass = saturate(glass);
+
+    float4 faceted = float4(glass * source.a, source.a);
+    return lerp(source, faceted, amount);
+}

--- a/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj
@@ -425,6 +425,12 @@
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
     </FxCompile>
+	<FxCompile Include="FacetedGlass.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+    </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Hash.hlsli" />

--- a/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj.filters
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj.filters
@@ -156,6 +156,9 @@
     <FxCompile Include="PuppetDeformationArap.hlsl">
       <Filter>ソース ファイル</Filter>
     </FxCompile>
+    <FxCompile Include="FacetedGlass.hlsl">
+      <Filter>ソース ファイル</Filter>
+    </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Hash.hlsli">

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/FacetedGlassCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/FacetedGlassCustomEffect.cs
@@ -51,16 +51,16 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FacetedGlass
             private ConstantBuffer _cb;
 
             [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Amount)]
-            public float Amount { get => _cb.Amount; set { _cb.Amount = value; UpdateConstants(); } }
+            public float Amount { get => _cb.Amount; set { _cb.Amount = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
 
             [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.CellSize)]
             public float CellSize { get => _cb.CellSize; set { _cb.CellSize = Math.Max(value, 1f); UpdateConstants(); } }
 
             [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Irregularity)]
-            public float Irregularity { get => _cb.Irregularity; set { _cb.Irregularity = value; UpdateConstants(); } }
+            public float Irregularity { get => _cb.Irregularity; set { _cb.Irregularity = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
 
             [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Relief)]
-            public float Relief { get => _cb.Relief; set { _cb.Relief = value; UpdateConstants(); } }
+            public float Relief { get => _cb.Relief; set { _cb.Relief = Math.Clamp(value, 0f, 2f); UpdateConstants(); } }
 
             [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Rotation)]
             public float Rotation { get => _cb.Rotation; set { _cb.Rotation = value; UpdateConstants(); } }
@@ -69,7 +69,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FacetedGlass
             public float Evolution { get => _cb.Evolution; set { _cb.Evolution = value; UpdateConstants(); } }
 
             [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Refraction)]
-            public float Refraction { get => _cb.Refraction; set { _cb.Refraction = value; UpdateConstants(); } }
+            public float Refraction { get => _cb.Refraction; set { _cb.Refraction = Math.Max(value, 0f); UpdateConstants(); } }
 
             [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.RefractiveIndex)]
             public float RefractiveIndex { get => _cb.RefractiveIndex; set { _cb.RefractiveIndex = value; UpdateConstants(); } }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/FacetedGlassCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/FacetedGlassCustomEffect.cs
@@ -1,0 +1,159 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+using Vortice;
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Commons;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FacetedGlass
+{
+    public sealed class FacetedGlassCustomEffect(IGraphicsDevicesAndContext devices) : D2D1CustomShaderEffectBase(Create<EffectImpl>(devices))
+    {
+        private enum PropertyIndex
+        {
+            Amount = 0,
+            CellSize,
+            Irregularity,
+            Relief,
+            Rotation,
+            Evolution,
+            Refraction,
+            RefractiveIndex,
+            Dispersion,
+            Reflection,
+            Glint,
+            BorderWidth,
+            LightAngle,
+            LightElevation,
+            Seed,
+        }
+
+        public float Amount { set => SetValue((int)PropertyIndex.Amount, value); }
+        public float CellSize { set => SetValue((int)PropertyIndex.CellSize, value); }
+        public float Irregularity { set => SetValue((int)PropertyIndex.Irregularity, value); }
+        public float Relief { set => SetValue((int)PropertyIndex.Relief, value); }
+        public float Rotation { set => SetValue((int)PropertyIndex.Rotation, value); }
+        public float Evolution { set => SetValue((int)PropertyIndex.Evolution, value); }
+        public float Refraction { set => SetValue((int)PropertyIndex.Refraction, value); }
+        public float RefractiveIndex { set => SetValue((int)PropertyIndex.RefractiveIndex, value); }
+        public float Dispersion { set => SetValue((int)PropertyIndex.Dispersion, value); }
+        public float Reflection { set => SetValue((int)PropertyIndex.Reflection, value); }
+        public float Glint { set => SetValue((int)PropertyIndex.Glint, value); }
+        public float BorderWidth { set => SetValue((int)PropertyIndex.BorderWidth, value); }
+        public float LightAngle { set => SetValue((int)PropertyIndex.LightAngle, value); }
+        public float LightElevation { set => SetValue((int)PropertyIndex.LightElevation, value); }
+        public int Seed { set => SetValue((int)PropertyIndex.Seed, value); }
+
+        [CustomEffect(1)]
+        private sealed class EffectImpl : D2D1CustomShaderEffectImplBase<EffectImpl>
+        {
+            private ConstantBuffer _cb;
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Amount)]
+            public float Amount { get => _cb.Amount; set { _cb.Amount = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.CellSize)]
+            public float CellSize { get => _cb.CellSize; set { _cb.CellSize = Math.Max(value, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Irregularity)]
+            public float Irregularity { get => _cb.Irregularity; set { _cb.Irregularity = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Relief)]
+            public float Relief { get => _cb.Relief; set { _cb.Relief = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Rotation)]
+            public float Rotation { get => _cb.Rotation; set { _cb.Rotation = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Evolution)]
+            public float Evolution { get => _cb.Evolution; set { _cb.Evolution = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Refraction)]
+            public float Refraction { get => _cb.Refraction; set { _cb.Refraction = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.RefractiveIndex)]
+            public float RefractiveIndex { get => _cb.RefractiveIndex; set { _cb.RefractiveIndex = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Dispersion)]
+            public float Dispersion { get => _cb.Dispersion; set { _cb.Dispersion = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Reflection)]
+            public float Reflection { get => _cb.Reflection; set { _cb.Reflection = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Glint)]
+            public float Glint { get => _cb.Glint; set { _cb.Glint = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.BorderWidth)]
+            public float BorderWidth { get => _cb.BorderWidth; set { _cb.BorderWidth = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.LightAngle)]
+            public float LightAngle { get => _cb.LightAngle; set { _cb.LightAngle = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.LightElevation)]
+            public float LightElevation { get => _cb.LightElevation; set { _cb.LightElevation = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Int32, (int)PropertyIndex.Seed)]
+            public int Seed { get => _cb.Seed; set { _cb.Seed = value; UpdateConstants(); } }
+
+            public EffectImpl() : base(ShaderResourceUri.Get("FacetedGlass")) { }
+
+            protected override void UpdateConstants()
+            {
+                drawInformation?.SetPixelShaderConstantBuffer(_cb);
+            }
+
+            public override void MapInputRectsToOutputRect(
+                RawRect[] inputRects,
+                RawRect[] inputOpaqueSubRects,
+                out RawRect outputRect,
+                out RawRect outputOpaqueSubRect)
+            {
+                base.MapInputRectsToOutputRect(inputRects, inputOpaqueSubRects, out outputRect, out outputOpaqueSubRect);
+
+                if (inputRects.Length > 0)
+                {
+                    var r = inputRects[0];
+                    _cb.InputBounds = new Vector4(r.Left, r.Top, r.Right, r.Bottom);
+                    UpdateConstants();
+                }
+            }
+
+            public override void MapOutputRectToInputRects(RawRect outputRect, RawRect[] inputRects)
+            {
+                if (inputRects.Length == 0)
+                    return;
+
+                var margin = (int)Math.Ceiling(_cb.Refraction * 1.25f + 2f);
+                inputRects[0] = new RawRect(
+                    Saturate((long)outputRect.Left - margin),
+                    Saturate((long)outputRect.Top - margin),
+                    Saturate((long)outputRect.Right + margin),
+                    Saturate((long)outputRect.Bottom + margin));
+            }
+
+            private static int Saturate(long value) => (int)Math.Clamp(value, int.MinValue, int.MaxValue);
+
+            [StructLayout(LayoutKind.Sequential)]
+            private struct ConstantBuffer
+            {
+                public Vector4 InputBounds;
+                public float Amount;
+                public float CellSize;
+                public float Irregularity;
+                public float Relief;
+                public float Rotation;
+                public float Evolution;
+                public float Refraction;
+                public float RefractiveIndex;
+                public float Dispersion;
+                public float Reflection;
+                public float Glint;
+                public float BorderWidth;
+                public float LightAngle;
+                public float LightElevation;
+                public int Seed;
+                public float Pad0;
+            }
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/FacetedGlassEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/FacetedGlassEffect.cs
@@ -1,0 +1,95 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FacetedGlass
+{
+    [VideoEffect(nameof(Texts.FacetedGlass), [VideoEffectCategories.Filtering, VideoEffectCategories.Decoration], [nameof(Texts.TagGlass), nameof(Texts.TagPrism), nameof(Texts.TagRefraction), nameof(Texts.TagFacet)], IsAviUtlSupported = false, ResourceType = typeof(Texts))]
+    public sealed class FacetedGlassEffect : VideoEffectBase
+    {
+        public override string Label => Texts.FacetedGlass;
+
+        [Display(GroupName = nameof(Texts.BasicGroup), Name = nameof(Texts.Amount), Description = nameof(Texts.AmountDescription), Order = 0, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 100)]
+        public Animation Amount { get; } = new Animation(100, 0, 100);
+
+        [Display(GroupName = nameof(Texts.GeometryGroup), Name = nameof(Texts.CellSize), Description = nameof(Texts.CellSizeDescription), Order = 10, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", 8, 300)]
+        public Animation CellSize { get; } = new Animation(72, 8, 1000);
+
+        [Display(GroupName = nameof(Texts.GeometryGroup), Name = nameof(Texts.Irregularity), Description = nameof(Texts.IrregularityDescription), Order = 11, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 100)]
+        public Animation Irregularity { get; } = new Animation(65, 0, 100);
+
+        [Display(GroupName = nameof(Texts.GeometryGroup), Name = nameof(Texts.Relief), Description = nameof(Texts.ReliefDescription), Order = 12, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 200)]
+        public Animation Relief { get; } = new Animation(55, 0, 200);
+
+        [Display(GroupName = nameof(Texts.GeometryGroup), Name = nameof(Texts.Rotation), Description = nameof(Texts.RotationDescription), Order = 13, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "°", -180, 180)]
+        public Animation Rotation { get; } = new Animation(0, -180, 180);
+
+        [Display(GroupName = nameof(Texts.GeometryGroup), Name = nameof(Texts.Evolution), Description = nameof(Texts.EvolutionDescription), Order = 14, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "°", 0, 360)]
+        public Animation Evolution { get; } = new Animation(0, -36000, 36000);
+
+        [Display(GroupName = nameof(Texts.GeometryGroup), Name = nameof(Texts.Seed), Description = nameof(Texts.SeedDescription), Order = 15, ResourceType = typeof(Texts))]
+        [Range(0, int.MaxValue)]
+        [DefaultValue(0)]
+        [TextBoxSlider("F0", "", 0, 10000)]
+        public int Seed
+        {
+            get => _seed;
+            set => Set(ref _seed, Math.Max(value, 0));
+        }
+        private int _seed;
+
+        [Display(GroupName = nameof(Texts.OpticsGroup), Name = nameof(Texts.Refraction), Description = nameof(Texts.RefractionDescription), Order = 20, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", 0, 100)]
+        public Animation Refraction { get; } = new Animation(18, 0, 512);
+
+        [Display(GroupName = nameof(Texts.OpticsGroup), Name = nameof(Texts.RefractiveIndex), Description = nameof(Texts.RefractiveIndexDescription), Order = 21, ResourceType = typeof(Texts))]
+        [AnimationSlider("F2", "", 1, 2.5)]
+        public Animation RefractiveIndex { get; } = new Animation(1.5, 1, 2.5);
+
+        [Display(GroupName = nameof(Texts.OpticsGroup), Name = nameof(Texts.Dispersion), Description = nameof(Texts.DispersionDescription), Order = 22, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 100)]
+        public Animation Dispersion { get; } = new Animation(35, 0, 100);
+
+        [Display(GroupName = nameof(Texts.AppearanceGroup), Name = nameof(Texts.Reflection), Description = nameof(Texts.ReflectionDescription), Order = 30, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 200)]
+        public Animation Reflection { get; } = new Animation(55, 0, 200);
+
+        [Display(GroupName = nameof(Texts.AppearanceGroup), Name = nameof(Texts.Glint), Description = nameof(Texts.GlintDescription), Order = 31, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 200)]
+        public Animation Glint { get; } = new Animation(40, 0, 200);
+
+        [Display(GroupName = nameof(Texts.AppearanceGroup), Name = nameof(Texts.BorderWidth), Description = nameof(Texts.BorderWidthDescription), Order = 32, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", 0, 10)]
+        public Animation BorderWidth { get; } = new Animation(1, 0, 32);
+
+        [Display(GroupName = nameof(Texts.LightingGroup), Name = nameof(Texts.LightAngle), Description = nameof(Texts.LightAngleDescription), Order = 40, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "°", -180, 180)]
+        public Animation LightAngle { get; } = new Animation(-35, -180, 180);
+
+        [Display(GroupName = nameof(Texts.LightingGroup), Name = nameof(Texts.LightElevation), Description = nameof(Texts.LightElevationDescription), Order = 41, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "°", 1, 89)]
+        public Animation LightElevation { get; } = new Animation(45, 1, 89);
+
+        private IAnimatable[]? _animatables;
+
+        public override IEnumerable<string> CreateExoVideoFilters(
+            int keyFrameIndex,
+            ExoOutputDescription exoOutputDescription) => [];
+
+        public override IVideoEffectProcessor CreateVideoEffect(IGraphicsDevicesAndContext devices)
+            => new FacetedGlassEffectProcessor(devices, this);
+
+        protected override IEnumerable<IAnimatable> GetAnimatables()
+            => _animatables ??= [Amount, CellSize, Irregularity, Relief, Rotation, Evolution, Refraction, RefractiveIndex, Dispersion, Reflection, Glint, BorderWidth, LightAngle, LightElevation];
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/FacetedGlassEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/FacetedGlassEffectProcessor.cs
@@ -1,0 +1,112 @@
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Player.Video.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FacetedGlass
+{
+    internal sealed class FacetedGlassEffectProcessor(
+        IGraphicsDevicesAndContext devices,
+        FacetedGlassEffect item) : VideoEffectProcessorBase(devices)
+    {
+        private readonly FacetedGlassEffect _item = item;
+        private FacetedGlassCustomEffect? _effect;
+
+        private bool _isFirst = true;
+        private Parameters _parameters;
+
+        public override DrawDescription Update(EffectDescription effectDescription)
+        {
+            if (IsPassThroughEffect || _effect is null)
+                return effectDescription.DrawDescription;
+
+            var frame = effectDescription.ItemPosition.Frame;
+            var length = effectDescription.ItemDuration.Frame;
+            var fps = effectDescription.FPS;
+
+            var parameters = new Parameters(
+                (float)(_item.Amount.GetValue(frame, length, fps) / 100.0),
+                (float)_item.CellSize.GetValue(frame, length, fps),
+                (float)(_item.Irregularity.GetValue(frame, length, fps) / 100.0),
+                (float)(_item.Relief.GetValue(frame, length, fps) / 100.0),
+                (float)_item.Rotation.GetValue(frame, length, fps),
+                (float)(_item.Evolution.GetValue(frame, length, fps) * Math.PI / 180.0),
+                (float)_item.Refraction.GetValue(frame, length, fps),
+                (float)_item.RefractiveIndex.GetValue(frame, length, fps),
+                (float)(_item.Dispersion.GetValue(frame, length, fps) / 100.0),
+                (float)(_item.Reflection.GetValue(frame, length, fps) / 100.0),
+                (float)(_item.Glint.GetValue(frame, length, fps) / 100.0),
+                (float)_item.BorderWidth.GetValue(frame, length, fps),
+                (float)_item.LightAngle.GetValue(frame, length, fps),
+                (float)_item.LightElevation.GetValue(frame, length, fps),
+                _item.Seed);
+
+            if (_isFirst || _parameters != parameters)
+            {
+                _effect.Amount = parameters.Amount;
+                _effect.CellSize = parameters.CellSize;
+                _effect.Irregularity = parameters.Irregularity;
+                _effect.Relief = parameters.Relief;
+                _effect.Rotation = parameters.Rotation;
+                _effect.Evolution = parameters.Evolution;
+                _effect.Refraction = parameters.Refraction;
+                _effect.RefractiveIndex = parameters.RefractiveIndex;
+                _effect.Dispersion = parameters.Dispersion;
+                _effect.Reflection = parameters.Reflection;
+                _effect.Glint = parameters.Glint;
+                _effect.BorderWidth = parameters.BorderWidth;
+                _effect.LightAngle = parameters.LightAngle;
+                _effect.LightElevation = parameters.LightElevation;
+                _effect.Seed = parameters.Seed;
+                _parameters = parameters;
+                _isFirst = false;
+            }
+
+            return effectDescription.DrawDescription;
+        }
+
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            _effect = new FacetedGlassCustomEffect(devices);
+            if (!_effect.IsEnabled)
+            {
+                _effect.Dispose();
+                _effect = null;
+                return null;
+            }
+            disposer.Collect(_effect);
+
+            var output = _effect.Output;
+            disposer.Collect(output);
+            return output;
+        }
+
+        protected override void setInput(ID2D1Image? input)
+        {
+            _effect?.SetInput(0, input, true);
+        }
+
+        protected override void ClearEffectChain()
+        {
+            _effect?.SetInput(0, null, true);
+            _isFirst = true;
+        }
+
+        private readonly record struct Parameters(
+            float Amount,
+            float CellSize,
+            float Irregularity,
+            float Relief,
+            float Rotation,
+            float Evolution,
+            float Refraction,
+            float RefractiveIndex,
+            float Dispersion,
+            float Reflection,
+            float Glint,
+            float BorderWidth,
+            float LightAngle,
+            float LightElevation,
+            int Seed);
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/FacetedGlassEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/FacetedGlassEffectProcessor.cs
@@ -41,26 +41,39 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FacetedGlass
                 (float)_item.LightElevation.GetValue(frame, length, fps),
                 _item.Seed);
 
-            if (_isFirst || _parameters != parameters)
-            {
+            if (_isFirst || _parameters.Amount != parameters.Amount)
                 _effect.Amount = parameters.Amount;
+            if (_isFirst || _parameters.CellSize != parameters.CellSize)
                 _effect.CellSize = parameters.CellSize;
+            if (_isFirst || _parameters.Irregularity != parameters.Irregularity)
                 _effect.Irregularity = parameters.Irregularity;
+            if (_isFirst || _parameters.Relief != parameters.Relief)
                 _effect.Relief = parameters.Relief;
+            if (_isFirst || _parameters.Rotation != parameters.Rotation)
                 _effect.Rotation = parameters.Rotation;
+            if (_isFirst || _parameters.Evolution != parameters.Evolution)
                 _effect.Evolution = parameters.Evolution;
+            if (_isFirst || _parameters.Refraction != parameters.Refraction)
                 _effect.Refraction = parameters.Refraction;
+            if (_isFirst || _parameters.RefractiveIndex != parameters.RefractiveIndex)
                 _effect.RefractiveIndex = parameters.RefractiveIndex;
+            if (_isFirst || _parameters.Dispersion != parameters.Dispersion)
                 _effect.Dispersion = parameters.Dispersion;
+            if (_isFirst || _parameters.Reflection != parameters.Reflection)
                 _effect.Reflection = parameters.Reflection;
+            if (_isFirst || _parameters.Glint != parameters.Glint)
                 _effect.Glint = parameters.Glint;
+            if (_isFirst || _parameters.BorderWidth != parameters.BorderWidth)
                 _effect.BorderWidth = parameters.BorderWidth;
+            if (_isFirst || _parameters.LightAngle != parameters.LightAngle)
                 _effect.LightAngle = parameters.LightAngle;
+            if (_isFirst || _parameters.LightElevation != parameters.LightElevation)
                 _effect.LightElevation = parameters.LightElevation;
+            if (_isFirst || _parameters.Seed != parameters.Seed)
                 _effect.Seed = parameters.Seed;
-                _parameters = parameters;
-                _isFirst = false;
-            }
+
+            _parameters = parameters;
+            _isFirst = false;
 
             return effectDescription.DrawDescription;
         }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/Texts.cs
@@ -1,0 +1,10 @@
+using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.FacetedGlass
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/Texts.csv
@@ -1,0 +1,41 @@
+Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+FacetedGlass,,多面体ガラス,Faceted Glass,多面玻璃,多面玻璃,다면 유리,Vidrio facetado,زجاج متعدد الأوجه,Kaca Bersegi
+BasicGroup,,基本,Basic,基本,基本,기본,Básico,أساسي,Dasar
+GeometryGroup,,面構造,Facet Geometry,面结构,面結構,면 구조,Geometría de facetas,هندسة الأوجه,Geometri Faset
+OpticsGroup,,光学,Optics,光学,光學,광학,Óptica,البصريات,Optik
+AppearanceGroup,,外観,Appearance,外观,外觀,외관,Apariencia,المظهر,Tampilan
+LightingGroup,,照明,Lighting,照明,照明,조명,Iluminación,الإضاءة,Pencahayaan
+Amount,,強さ,Amount,强度,強度,강도,Intensidad,القوة,Kekuatan
+AmountDescription,,元映像と多面体ガラスの合成量です,Controls the blend between the source and faceted glass.,控制原始画面与多面玻璃的混合量。,控制原始畫面與多面玻璃的混合量。,원본과 다면 유리의 합성량입니다.,Controla la mezcla con el vidrio facetado.,يتحكم في مزج المصدر مع الزجاج متعدد الأوجه.,Mengatur campuran sumber dan kaca bersegi.
+CellSize,,面サイズ,Facet Size,面大小,面大小,면 크기,Tamaño de faceta,حجم الوجه,Ukuran Faset
+CellSizeDescription,,面ひとつあたりの平均サイズです,Sets the average size of each facet.,设置每个面的平均大小。,設定每個面的平均大小。,면 하나의 평균 크기입니다.,Define el tamaño medio de cada faceta.,يضبط متوسط حجم كل وجه.,Mengatur ukuran rata-rata setiap faset.
+Irregularity,,不規則さ,Irregularity,不规则度,不規則度,불규칙성,Irregularidad,عدم الانتظام,Ketidakteraturan
+IrregularityDescription,,0%で正六角形、100%で有機的な破片状の面になります,Morphs facets from regular hexagons (0%) to organic shards (100%).,0%为正六边形，100%为有机碎片状。,0%為正六邊形，100%為有機碎片狀。,0%는 정육각형, 100%는 유기적인 파편 모양이 됩니다.,Transforma las facetas de hexágonos (0%) a fragmentos orgánicos (100%).,يحول الأوجه من سداسيات منتظمة (0%) إلى شظايا عضوية (100%).,Mengubah faset dari heksagon teratur (0%) menjadi pecahan organik (100%).
+Relief,,凹凸,Relief,凹凸,凹凸,요철,Relieve,التضاريس,Relief
+ReliefDescription,,面ごとの傾きの強さです,Controls the tilt strength of each facet.,控制每个面的倾斜强度。,控制每個面的傾斜強度。,면마다의 기울기 강도입니다.,Controla la inclinación de cada faceta.,يتحكم في قوة ميل كل وجه.,Mengatur kekuatan kemiringan setiap faset.
+Rotation,,分割角度,Grid Rotation,分割角度,分割角度,분할 각도,Rotación de cuadrícula,دوران الشبكة,Rotasi Kisi
+RotationDescription,,面分割全体の角度です,Rotates the entire facet layout.,旋转整个面分割。,旋轉整個面分割。,면 분할 전체를 회전합니다.,Gira toda la disposición de facetas.,يدير تخطيط الأوجه بالكامل.,Memutar seluruh tata letak faset.
+Evolution,,ゆらぎ,Evolution,流转,流轉,일렁임,Fluctuación,التموج,Fluktuasi
+EvolutionDescription,,面の傾きが呼吸するように変化します。アニメーションさせると生きたガラスになります,Facet tilts breathe and drift. Animate it to bring the glass to life.,面的倾斜如呼吸般变化。设置动画可让玻璃生动起来。,面的傾斜如呼吸般變化。設定動畫可讓玻璃生動起來。,면의 기울기가 숨 쉬듯 변화합니다. 애니메이션으로 살아있는 유리가 됩니다.,Las facetas respiran y derivan. Anímalo para dar vida al vidrio.,تتنفس ميول الأوجه وتنجرف. حرّكه لبث الحياة في الزجاج.,Kemiringan faset bernapas dan bergeser. Animasikan agar kaca menjadi hidup.
+Seed,,シード,Seed,种子,種子,시드,Semilla,البذرة,Seed
+SeedDescription,,面の配置と傾きを決定する固定値です,Sets the deterministic facet layout and tilt pattern.,设置确定性的面排列与倾斜。,設定確定性的面排列與傾斜。,결정론적 면 배치와 기울기를 정합니다.,Define el patrón determinista de facetas.,يضبط النمط الحتمي لتخطيط الأوجه وميلها.,Mengatur pola tata letak dan kemiringan faset yang deterministik.
+Refraction,,屈折,Refraction,折射,折射,굴절,Refracción,الانكسار,Refraksi
+RefractionDescription,,面法線による映像のずれ量です,Controls image displacement caused by facet refraction.,控制面法线产生的画面偏移。,控制面法線產生的畫面偏移。,면 법선에 의한 영상 이동량입니다.,Controla el desplazamiento por refracción.,يتحكم في إزاحة الصورة بسبب الانكسار.,Mengatur pergeseran gambar akibat refraksi.
+RefractiveIndex,,屈折率,Refractive Index,折射率,折射率,굴절률,Índice de refracción,معامل الانكسار,Indeks Refraksi
+RefractiveIndexDescription,,基準波長におけるガラスの屈折率です,Sets the glass index at the reference wavelength.,设置参考波长下的玻璃折射率。,設定參考波長下的玻璃折射率。,기준 파장에서 유리의 굴절률입니다.,Define el índice del vidrio en la longitud de referencia.,يضبط معامل انكسار الزجاج عند الطول المرجعي.,Mengatur indeks kaca pada panjang gelombang referensi.
+Dispersion,,分散,Dispersion,色散,色散,분산,Dispersión,التشتت,Dispersi
+DispersionDescription,,波長ごとの屈折率差による色分離です,Controls wavelength dependent color separation.,控制波长相关折射率差产生的分色。,控制波長相關折射率差產生的分色。,파장별 굴절률 차이에 의한 색 분리입니다.,Controla la separación cromática por longitud de onda.,يتحكم في فصل الألوان المعتمد على الطول الموجي.,Mengatur pemisahan warna berdasarkan panjang gelombang.
+Reflection,,反射,Reflection,反射,反射,반사,Reflexión,الانعكاس,Refleksi
+ReflectionDescription,,Fresnel反射と鏡面ハイライトの強さです,Controls Fresnel reflection and specular highlights.,控制Fresnel反射和镜面高光。,控制Fresnel反射和鏡面高光。,프레넬 반사와 정반사 하이라이트 강도입니다.,Controla la reflexión Fresnel y los brillos.,يتحكم في انعكاس فرينل واللمعان المرآتي.,Mengatur refleksi Fresnel dan sorotan spekular.
+Glint,,きらめき,Glint,闪光,閃光,반짝임,Destello,البريق,Kilauan
+GlintDescription,,面ごとに明滅する鋭い閃光の強さです。ゆらぎと連動します,Sets the sharp per-facet flashes that pulse with Evolution.,设置随流转明灭的面级锐利闪光。,設定隨流轉明滅的面級銳利閃光。,일렁임과 연동해 면마다 명멸하는 날카로운 섬광입니다.,Define los destellos por faceta que pulsan con la fluctuación.,يضبط الومضات الحادة لكل وجه التي تنبض مع التموج.,Mengatur kilatan tajam per faset yang berdenyut mengikuti fluktuasi.
+BorderWidth,,面境界,Facet Border,面边界,面邊界,면 경계,Borde de faceta,حدود الأوجه,Batas Faset
+BorderWidthDescription,,面の境界に現れる反射線の幅です,Sets the reflective line width at facet edges.,设置面边界反射线宽度。,設定面邊界反射線寬度。,면 경계의 반사선 폭입니다.,Define el ancho reflectante de los bordes.,يضبط عرض الخط العاكس عند حواف الأوجه.,Mengatur lebar garis reflektif pada tepi faset.
+LightAngle,,光源角度,Light Angle,光源角度,光源角度,광원 각도,Ángulo de luz,زاوية الضوء,Sudut Cahaya
+LightAngleDescription,,平面上の光源方向です,Sets the light direction in the image plane.,设置图像平面上的光源方向。,設定影像平面上的光源方向。,영상 평면의 광원 방향입니다.,Define la dirección de la luz en el plano.,يضبط اتجاه الضوء على مستوى الصورة.,Mengatur arah cahaya pada bidang gambar.
+LightElevation,,光源高度,Light Elevation,光源高度,光源高度,광원 고도,Elevación de luz,ارتفاع الضوء,Ketinggian Cahaya
+LightElevationDescription,,面に対する光源の高さです,Sets the elevation of the light above the surface.,设置光源相对表面的高度。,設定光源相對表面的高度。,표면 위 광원의 고도입니다.,Define la elevación de la luz sobre la superficie.,يضبط ارتفاع الضوء فوق السطح.,Mengatur ketinggian cahaya di atas permukaan.
+TagGlass,,ガラス,glass,玻璃,玻璃,유리,vidrio,زجاج,kaca
+TagPrism,,プリズム,prism,棱镜,稜鏡,프리즘,prisma,منشور,prisma
+TagRefraction,,屈折,refraction,折射,折射,굴절,refracción,انكسار,refraksi
+TagFacet,,多面体,facet,多面体,多面體,다면체,faceta,متعدد الأوجه,faset

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/FacetedGlass/Texts.csv
@@ -10,7 +10,7 @@ AmountDescription,,元映像と多面体ガラスの合成量です,Controls the
 CellSize,,面サイズ,Facet Size,面大小,面大小,면 크기,Tamaño de faceta,حجم الوجه,Ukuran Faset
 CellSizeDescription,,面ひとつあたりの平均サイズです,Sets the average size of each facet.,设置每个面的平均大小。,設定每個面的平均大小。,면 하나의 평균 크기입니다.,Define el tamaño medio de cada faceta.,يضبط متوسط حجم كل وجه.,Mengatur ukuran rata-rata setiap faset.
 Irregularity,,不規則さ,Irregularity,不规则度,不規則度,불규칙성,Irregularidad,عدم الانتظام,Ketidakteraturan
-IrregularityDescription,,0%で正六角形、100%で有機的な破片状の面になります,Morphs facets from regular hexagons (0%) to organic shards (100%).,0%为正六边形，100%为有机碎片状。,0%為正六邊形，100%為有機碎片狀。,0%는 정육각형, 100%는 유기적인 파편 모양이 됩니다.,Transforma las facetas de hexágonos (0%) a fragmentos orgánicos (100%).,يحول الأوجه من سداسيات منتظمة (0%) إلى شظايا عضوية (100%).,Mengubah faset dari heksagon teratur (0%) menjadi pecahan organik (100%).
+IrregularityDescription,,0%で正六角形、100%で有機的な破片状の面になります,Morphs facets from regular hexagons (0%) to organic shards (100%).,0%为正六边形，100%为有机碎片状。,0%為正六邊形，100%為有機碎片狀。,"0%는 정육각형, 100%는 유기적인 파편 모양이 됩니다.",Transforma las facetas de hexágonos (0%) a fragmentos orgánicos (100%).,يحول الأوجه من سداسيات منتظمة (0%) إلى شظايا عضوية (100%).,Mengubah faset dari heksagon teratur (0%) menjadi pecahan organik (100%).
 Relief,,凹凸,Relief,凹凸,凹凸,요철,Relieve,التضاريس,Relief
 ReliefDescription,,面ごとの傾きの強さです,Controls the tilt strength of each facet.,控制每个面的倾斜强度。,控制每個面的傾斜強度。,면마다의 기울기 강도입니다.,Controla la inclinación de cada faceta.,يتحكم في قوة ميل كل وجه.,Mengatur kekuatan kemiringan setiap faset.
 Rotation,,分割角度,Grid Rotation,分割角度,分割角度,분할 각도,Rotación de cuadrícula,دوران الشبكة,Rotasi Kisi

--- a/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
+++ b/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
@@ -173,6 +173,7 @@
 	  <Resource Include="$(ShaderDirPath)AnisotropicKuwaharaTensor.cso" Link="Resources\Shader\AnisotropicKuwaharaTensor.cso" />
 	  <Resource Include="$(ShaderDirPath)AnisotropicKuwaharaTensorBlur.cso" Link="Resources\Shader\AnisotropicKuwaharaTensorBlur.cso" />
 	  <Resource Include="$(ShaderDirPath)AnisotropicKuwahara.cso" Link="Resources\Shader\AnisotropicKuwahara.cso" />
+	  <Resource Include="$(ShaderDirPath)FacetedGlass.cso" Link="Resources\Shader\FacetedGlass.cso" />
   </ItemGroup>
 
   <!-- internalsを参照するテスト（EdgeDetectionZeroStrengthOverlayTest等）はDEBUG限定のため、Releaseビルドには付与しない -->


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [x] このPRには1つの機能（または1つの修正）のみが含まれています
- [x] `YukkuriMovieMaker.dll`などYMM4本体の内部実装アセンブリを参照していません

## 概要
<!-- 変更内容を簡単に記載してください -->
新しい映像エフェクト「多面体ガラス」を追加します。
映像を多面体のガラス面へ分割し、面ごとの屈折と反射によってカットガラス越しに見たような表現へ変換するエフェクトです。波長ごとの屈折率差による色分離や、面の境界に現れる反射線もあわせて表現できます。

## エフェクト本体
六角格子を基準としたボロノイ分割で映像を面へ分割し、面ごとに割り当てた法線から屈折と反射を計算します。不規則さのパラメータにより、0%では正六角形のハニカム状、100%では有機的な破片状へと面の形が連続的に変化します。ゆらぎのパラメータは面の傾きを呼吸するように変化させる位相で、アニメーションさせると面の傾きときらめきが連動して動きます。きらめきは面ごとに位相の異なる鋭い閃光で、静止時にも面ごとの強弱として現れます。シード値は面の配置と傾きを固定するための値のため、ちらつき防止の観点から固定値としています。シード値を除く数値パラメータはすべてアニメーションに対応しています。
色分離はCauchyの式で波長ごとの屈折率を求め、RGBを別々の方向へ屈折させることで表現しています。反射はSchlickの近似によるフレネル項と鏡面ハイライトから構成し、光源の角度と高度を指定できます。
D2Dカスタムエフェクトのピクセルシェーダーとして実装しています。面の境界線はボロノイの正確な境界距離から求め、fwidthによるアンチエイリアスを適用しています。透過素材ではアルファを維持したまま面の内側のみへ効果を適用します。出力矩形は入力と同一で、屈折によるサンプリングは入力境界内にクランプしています。

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/72ed25b0-9ed2-4494-9ae0-7cebc135a961" />