### PR TITLE
映像エフェクト「万華鏡」を追加

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community.Shader/Kaleidoscope.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/Kaleidoscope.hlsl
@@ -1,0 +1,57 @@
+Texture2D SourceTexture : register(t0);
+SamplerState SourceSampler : register(s0);
+
+cbuffer Constants : register(b0)
+{
+    float4 inputBounds : packoffset(c0);
+    float segments : packoffset(c1.x);
+    float rotation : packoffset(c1.y);
+    float zoom : packoffset(c1.z);
+    float centerX : packoffset(c1.w);
+    float centerY : packoffset(c2.x);
+    float mirror : packoffset(c2.y);
+    float amount : packoffset(c2.z);
+    float pad0 : packoffset(c2.w);
+};
+
+static const float TWO_PI = 6.28318530718f;
+
+float4 main(
+    float4 position : SV_POSITION,
+    float4 scenePosition : SCENE_POSITION,
+    float4 uv0 : TEXCOORD0
+) : SV_TARGET
+{
+    float4 source = SourceTexture.SampleLevel(SourceSampler, uv0.xy, 0);
+    if (amount <= 0.0)
+        return source;
+
+    float2 halfSize = (inputBounds.zw - inputBounds.xy) * 0.5;
+    float2 imageCenter = (inputBounds.xy + inputBounds.zw) * 0.5;
+    float2 center = imageCenter + float2(centerX, centerY) * halfSize;
+
+    float2 delta = scenePosition.xy - center;
+    float radius = length(delta);
+    float segmentAngle = TWO_PI / max(segments, 1.0);
+
+    float angle = atan2(delta.y, delta.x) - rotation;
+    float folded = angle - segmentAngle * floor(angle / segmentAngle);
+    if (mirror >= 0.5)
+    {
+        float halfSegment = segmentAngle * 0.5;
+        folded = halfSegment - abs(folded - halfSegment);
+    }
+    folded += rotation;
+
+    float sampledRadius = radius / max(zoom, 1e-3);
+    float2 direction = float2(cos(folded), sin(folded));
+    float2 samplePosition = center + direction * sampledRadius;
+
+    float2 minimum = inputBounds.xy + 0.5;
+    float2 maximum = inputBounds.zw - 0.5;
+    float2 clamped = clamp(samplePosition, minimum, maximum);
+    float2 uv = uv0.xy + (clamped - scenePosition.xy) * uv0.zw;
+
+    float4 kaleido = SourceTexture.SampleLevel(SourceSampler, uv, 0);
+    return lerp(source, kaleido, amount);
+}

--- a/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj
@@ -425,6 +425,12 @@
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
     </FxCompile>
+	<FxCompile Include="Kaleidoscope.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+    </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Hash.hlsli" />

--- a/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj.filters
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj.filters
@@ -156,6 +156,9 @@
     <FxCompile Include="PuppetDeformationArap.hlsl">
       <Filter>ソース ファイル</Filter>
     </FxCompile>
+    <FxCompile Include="Kaleidoscope.hlsl">
+      <Filter>ソース ファイル</Filter>
+    </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Hash.hlsli">

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Kaleidoscope/KaleidoscopeCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Kaleidoscope/KaleidoscopeCustomEffect.cs
@@ -70,12 +70,9 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Kaleidoscope
             {
                 base.MapInputRectsToOutputRect(inputRects, inputOpaqueSubRects, out outputRect, out outputOpaqueSubRect);
 
-                if (inputRects.Length > 0)
-                {
-                    var r = inputRects[0];
-                    _cb.InputBounds = new Vector4(r.Left, r.Top, r.Right, r.Bottom);
-                    UpdateConstants();
-                }
+                inputRect = ClampInputRect(inputRect);
+                _cb.InputBounds = new Vector4(inputRect.Left, inputRect.Top, inputRect.Right, inputRect.Bottom);
+                UpdateConstants();
             }
 
             public override void MapOutputRectToInputRects(RawRect outputRect, RawRect[] inputRects)

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Kaleidoscope/KaleidoscopeCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Kaleidoscope/KaleidoscopeCustomEffect.cs
@@ -1,0 +1,104 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+using Vortice;
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Commons;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Kaleidoscope
+{
+    public sealed class KaleidoscopeCustomEffect(IGraphicsDevicesAndContext devices) : D2D1CustomShaderEffectBase(Create<EffectImpl>(devices))
+    {
+        private enum PropertyIndex
+        {
+            Segments = 0,
+            Rotation,
+            Zoom,
+            CenterX,
+            CenterY,
+            Mirror,
+            Amount,
+        }
+
+        public float Segments { set => SetValue((int)PropertyIndex.Segments, value); }
+        public float Rotation { set => SetValue((int)PropertyIndex.Rotation, value); }
+        public float Zoom { set => SetValue((int)PropertyIndex.Zoom, value); }
+        public float CenterX { set => SetValue((int)PropertyIndex.CenterX, value); }
+        public float CenterY { set => SetValue((int)PropertyIndex.CenterY, value); }
+        public float Mirror { set => SetValue((int)PropertyIndex.Mirror, value); }
+        public float Amount { set => SetValue((int)PropertyIndex.Amount, value); }
+
+        [CustomEffect(1)]
+        private sealed class EffectImpl : D2D1CustomShaderEffectImplBase<EffectImpl>
+        {
+            private ConstantBuffer _cb;
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Segments)]
+            public float Segments { get => _cb.Segments; set { _cb.Segments = Math.Clamp(value, 1f, 256f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Rotation)]
+            public float Rotation { get => _cb.Rotation; set { _cb.Rotation = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Zoom)]
+            public float Zoom { get => _cb.Zoom; set { _cb.Zoom = Math.Clamp(value, 1e-3f, 1e4f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.CenterX)]
+            public float CenterX { get => _cb.CenterX; set { _cb.CenterX = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.CenterY)]
+            public float CenterY { get => _cb.CenterY; set { _cb.CenterY = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Mirror)]
+            public float Mirror { get => _cb.Mirror; set { _cb.Mirror = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Amount)]
+            public float Amount { get => _cb.Amount; set { _cb.Amount = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            public EffectImpl() : base(ShaderResourceUri.Get("Kaleidoscope")) { }
+
+            protected override void UpdateConstants()
+            {
+                drawInformation?.SetPixelShaderConstantBuffer(_cb);
+            }
+
+            public override void MapInputRectsToOutputRect(
+                RawRect[] inputRects,
+                RawRect[] inputOpaqueSubRects,
+                out RawRect outputRect,
+                out RawRect outputOpaqueSubRect)
+            {
+                base.MapInputRectsToOutputRect(inputRects, inputOpaqueSubRects, out outputRect, out outputOpaqueSubRect);
+
+                if (inputRects.Length > 0)
+                {
+                    var r = inputRects[0];
+                    _cb.InputBounds = new Vector4(r.Left, r.Top, r.Right, r.Bottom);
+                    UpdateConstants();
+                }
+            }
+
+            public override void MapOutputRectToInputRects(RawRect outputRect, RawRect[] inputRects)
+            {
+                if (inputRects.Length == 0)
+                    return;
+
+                inputRects[0] = inputRect;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            private struct ConstantBuffer
+            {
+                public Vector4 InputBounds;
+                public float Segments;
+                public float Rotation;
+                public float Zoom;
+                public float CenterX;
+                public float CenterY;
+                public float Mirror;
+                public float Amount;
+                public float Pad0;
+            }
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Kaleidoscope/KaleidoscopeEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Kaleidoscope/KaleidoscopeEffect.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel.DataAnnotations;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Kaleidoscope
+{
+    [VideoEffect(nameof(Texts.Kaleidoscope), [VideoEffectCategories.Filtering], [nameof(Texts.TagKaleidoscope), nameof(Texts.TagMirror), nameof(Texts.TagSymmetry)], IsAviUtlSupported = false, ResourceType = typeof(Texts))]
+    public sealed class KaleidoscopeEffect : VideoEffectBase
+    {
+        public override string Label => Texts.Kaleidoscope;
+
+        [Display(GroupName = nameof(Texts.Kaleidoscope), Name = nameof(Texts.Segments), Description = nameof(Texts.SegmentsDescription), Order = 0, ResourceType = typeof(Texts))]
+        [AnimationSlider("F0", "", 2, 24)]
+        public Animation Segments { get; } = new Animation(6, 1, 256);
+
+        [Display(GroupName = nameof(Texts.Kaleidoscope), Name = nameof(Texts.Rotation), Description = nameof(Texts.RotationDescription), Order = 1, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "°", -180, 180)]
+        public Animation Rotation { get; } = new Animation(0, -36000, 36000);
+
+        [Display(GroupName = nameof(Texts.Kaleidoscope), Name = nameof(Texts.Zoom), Description = nameof(Texts.ZoomDescription), Order = 2, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 10, 400)]
+        public Animation Zoom { get; } = new Animation(100, 1, 2000);
+
+        [Display(GroupName = nameof(Texts.Kaleidoscope), Name = nameof(Texts.CenterX), Description = nameof(Texts.CenterXDescription), Order = 3, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", -100, 100)]
+        public Animation CenterX { get; } = new Animation(0, -500, 500);
+
+        [Display(GroupName = nameof(Texts.Kaleidoscope), Name = nameof(Texts.CenterY), Description = nameof(Texts.CenterYDescription), Order = 4, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", -100, 100)]
+        public Animation CenterY { get; } = new Animation(0, -500, 500);
+
+        [Display(GroupName = nameof(Texts.Kaleidoscope), Name = nameof(Texts.Amount), Description = nameof(Texts.AmountDescription), Order = 5, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 100)]
+        public Animation Amount { get; } = new Animation(100, 0, 100);
+
+        [Display(GroupName = nameof(Texts.Kaleidoscope), Name = nameof(Texts.Mirror), Description = nameof(Texts.MirrorDescription), Order = 6, ResourceType = typeof(Texts))]
+        [ToggleSlider]
+        public bool Mirror
+        {
+            get => _mirror;
+            set => Set(ref _mirror, value);
+        }
+        private bool _mirror = true;
+
+        private IAnimatable[]? _animatables;
+
+        public override IEnumerable<string> CreateExoVideoFilters(
+            int keyFrameIndex,
+            ExoOutputDescription exoOutputDescription) => [];
+
+        public override IVideoEffectProcessor CreateVideoEffect(IGraphicsDevicesAndContext devices)
+            => new KaleidoscopeEffectProcessor(devices, this);
+
+        protected override IEnumerable<IAnimatable> GetAnimatables()
+            => _animatables ??= [Segments, Rotation, Zoom, CenterX, CenterY, Amount];
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Kaleidoscope/KaleidoscopeEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Kaleidoscope/KaleidoscopeEffectProcessor.cs
@@ -1,0 +1,93 @@
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Player.Video.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Kaleidoscope
+{
+    internal sealed class KaleidoscopeEffectProcessor(
+        IGraphicsDevicesAndContext devices,
+        KaleidoscopeEffect item) : VideoEffectProcessorBase(devices)
+    {
+        private readonly KaleidoscopeEffect _item = item;
+        private KaleidoscopeCustomEffect? _effect;
+
+        private bool _isFirst = true;
+        private Parameters _parameters;
+
+        public override DrawDescription Update(EffectDescription effectDescription)
+        {
+            if (IsPassThroughEffect || _effect is null)
+                return effectDescription.DrawDescription;
+
+            var frame = effectDescription.ItemPosition.Frame;
+            var length = effectDescription.ItemDuration.Frame;
+            var fps = effectDescription.FPS;
+
+            var parameters = new Parameters(
+                (float)_item.Segments.GetValue(frame, length, fps),
+                (float)(_item.Rotation.GetValue(frame, length, fps) * Math.PI / 180.0),
+                (float)(_item.Zoom.GetValue(frame, length, fps) / 100.0),
+                (float)(_item.CenterX.GetValue(frame, length, fps) / 100.0),
+                (float)(_item.CenterY.GetValue(frame, length, fps) / 100.0),
+                _item.Mirror ? 1f : 0f,
+                (float)(_item.Amount.GetValue(frame, length, fps) / 100.0));
+
+            if (_isFirst || _parameters.Segments != parameters.Segments)
+                _effect.Segments = parameters.Segments;
+            if (_isFirst || _parameters.Rotation != parameters.Rotation)
+                _effect.Rotation = parameters.Rotation;
+            if (_isFirst || _parameters.Zoom != parameters.Zoom)
+                _effect.Zoom = parameters.Zoom;
+            if (_isFirst || _parameters.CenterX != parameters.CenterX)
+                _effect.CenterX = parameters.CenterX;
+            if (_isFirst || _parameters.CenterY != parameters.CenterY)
+                _effect.CenterY = parameters.CenterY;
+            if (_isFirst || _parameters.Mirror != parameters.Mirror)
+                _effect.Mirror = parameters.Mirror;
+            if (_isFirst || _parameters.Amount != parameters.Amount)
+                _effect.Amount = parameters.Amount;
+
+            _parameters = parameters;
+            _isFirst = false;
+
+            return effectDescription.DrawDescription;
+        }
+
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            _effect = new KaleidoscopeCustomEffect(devices);
+            if (!_effect.IsEnabled)
+            {
+                _effect.Dispose();
+                _effect = null;
+                return null;
+            }
+            disposer.Collect(_effect);
+
+            var output = _effect.Output;
+            disposer.Collect(output);
+            return output;
+        }
+
+        protected override void setInput(ID2D1Image? input)
+        {
+            _effect?.SetInput(0, input, true);
+        }
+
+        protected override void ClearEffectChain()
+        {
+            _effect?.SetInput(0, null, true);
+            _isFirst = true;
+        }
+
+        private readonly record struct Parameters(
+            float Segments,
+            float Rotation,
+            float Zoom,
+            float CenterX,
+            float CenterY,
+            float Mirror,
+            float Amount);
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Kaleidoscope/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Kaleidoscope/Texts.cs
@@ -1,0 +1,10 @@
+using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Kaleidoscope
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Kaleidoscope/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Kaleidoscope/Texts.csv
@@ -1,0 +1,19 @@
+Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+Kaleidoscope,,万華鏡,Kaleidoscope,万花筒,萬花筒,만화경,Caleidoscopio,منظار الأشكال,Kaleidoskop
+TagKaleidoscope,,万華鏡,Kaleidoscope,万花筒,萬花筒,만화경,Caleidoscopio,منظار الأشكال,Kaleidoskop
+TagMirror,,鏡,Mirror,镜像,鏡像,거울,Espejo,مرآة,Cermin
+TagSymmetry,,対称,Symmetry,对称,對稱,대칭,Simetría,تناظر,Simetri
+Segments,,分割数,Segments,分割数,分割數,분할 수,Segmentos,القطاعات,Segmen
+SegmentsDescription,,中心から放射状に鏡映する分割数,Number of segments mirrored radially around the center.,围绕中心径向镜像的分割数。,圍繞中心徑向鏡像的分割數。,중심을 기준으로 방사형으로 반사되는 분할 수.,Número de segmentos reflejados radialmente alrededor del centro.,عدد القطاعات المنعكسة شعاعيًا حول المركز.,Jumlah segmen yang dicerminkan secara radial di sekitar pusat.
+Rotation,,回転,Rotation,旋转,旋轉,회전,Rotación,تدوير,Rotasi
+RotationDescription,,万華鏡模様の回転角度,Rotation angle of the kaleidoscope pattern.,万花筒图案的旋转角度。,萬花筒圖案的旋轉角度。,만화경 무늬의 회전 각도.,Ángulo de rotación del patrón del caleidoscopio.,زاوية دوران نمط منظار الأشكال.,Sudut rotasi pola kaleidoskop.
+Zoom,,ズーム,Zoom,缩放,縮放,확대,Zoom,تكبير,Zoom
+ZoomDescription,,サンプリング半径の拡大率,Scale factor of the sampling radius.,采样半径的缩放比例。,取樣半徑的縮放比例。,샘플링 반경의 확대 비율.,Factor de escala del radio de muestreo.,معامل تحجيم نصف قطر أخذ العينات.,Faktor skala radius pengambilan sampel.
+CenterX,,中心X,Center X,中心X,中心X,중심 X,Centro X,المركز الأفقي,Pusat X
+CenterXDescription,,万華鏡の中心の水平位置,Horizontal position of the kaleidoscope center.,万花筒中心的水平位置。,萬花筒中心的水平位置。,만화경 중심의 수평 위치.,Posición horizontal del centro del caleidoscopio.,الموضع الأفقي لمركز منظار الأشكال.,Posisi horizontal pusat kaleidoskop.
+CenterY,,中心Y,Center Y,中心Y,中心Y,중심 Y,Centro Y,المركز الرأسي,Pusat Y
+CenterYDescription,,万華鏡の中心の垂直位置,Vertical position of the kaleidoscope center.,万花筒中心的垂直位置。,萬花筒中心的垂直位置。,만화경 중심의 수직 위치.,Posición vertical del centro del caleidoscopio.,الموضع العمودي لمركز منظار الأشكال.,Posisi vertikal pusat kaleidoskop.
+Amount,,適用量,Amount,应用量,應用量,적용량,Cantidad,المقدار,Jumlah
+AmountDescription,,元画像と効果の合成比率,Blend ratio between the source and the effect.,原图像与效果的混合比例。,原圖像與效果的混合比例。,원본 이미지와 효과의 합성 비율.,Proporción de mezcla entre la fuente y el efecto.,نسبة المزج بين المصدر والتأثير.,Rasio pencampuran antara sumber dan efek.
+Mirror,,ミラーリング,Mirror,镜像,鏡像,미러링,Espejo,انعكاس,Pencerminan
+MirrorDescription,,各分割を鏡映するか回転コピーにするかを切り替えます,Toggles whether each segment is mirrored or a rotated copy.,切换每个分割是镜像还是旋转副本。,切換每個分割是鏡像還是旋轉副本。,각 분할을 반사할지 회전 복사할지 전환합니다.,Alterna si cada segmento se refleja o es una copia rotada.,يبدل ما إذا كان كل قطاع منعكسًا أو نسخة مدورة.,Beralih apakah setiap segmen dicerminkan atau salinan yang diputar.

--- a/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
+++ b/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
@@ -173,6 +173,7 @@
 	  <Resource Include="$(ShaderDirPath)AnisotropicKuwaharaTensor.cso" Link="Resources\Shader\AnisotropicKuwaharaTensor.cso" />
 	  <Resource Include="$(ShaderDirPath)AnisotropicKuwaharaTensorBlur.cso" Link="Resources\Shader\AnisotropicKuwaharaTensorBlur.cso" />
 	  <Resource Include="$(ShaderDirPath)AnisotropicKuwahara.cso" Link="Resources\Shader\AnisotropicKuwahara.cso" />
+	  <Resource Include="$(ShaderDirPath)Kaleidoscope.cso" Link="Resources\Shader\Kaleidoscope.cso" />
   </ItemGroup>
 
   <!-- internalsを参照するテスト（EdgeDetectionZeroStrengthOverlayTest等）はDEBUG限定のため、Releaseビルドには付与しない -->


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [x] このPRには1つの機能（または1つの修正）のみが含まれています
- [x] `YukkuriMovieMaker.dll`などYMM4本体の内部実装アセンブリを参照していません

## 概要
<!-- 変更内容を簡単に記載してください -->
新しい映像エフェクト「万華鏡」を追加します。
中心から放射状に画像を鏡映して、扇形の対称模様を生成するエフェクトです。実際の万華鏡のように分割数と中心位置を指定でき、回転とズームをアニメーションさせることで模様を動かせます。

## エフェクト本体
出力画素のシーン座標を中心からの極座標に変換し、角度を1扇形の角度で折り返してから元の画像をサンプリングします。折り返しは鏡映と回転コピーを切り替えられます。鏡映では扇形の中央を軸に角度を反転させ、回転コピーでは扇形をそのまま複製します。半径はズーム率で割ってサンプリング位置を求めるため、模様の粗密を調整できます。

パラメータは分割数、回転、ズーム、中心X、中心Y、適用量、ミラーリングです。分割数から適用量までの6項目はアニメーションに対応します。回転は連続回転を表現できるよう許容範囲を±36000度まで確保しています。分割数は小数を指定すると分割数の間をなめらかに補間します。適用量が0のときは元画像をそのまま返します。乱数やシード値は使用しておらず、すべての出力はパラメータとシーン座標だけから決まる純関数のため、フレーム間でちらつきません。

D2Dカスタムエフェクトとしての実装上の要点は次のとおりです。座標計算は`SCENE_POSITION`と入力矩形を基準にしており、補助データを追加の入力テクスチャで渡していないため、タイル分割境界のアーティファクトが発生しません。折り返しによって生じるサンプリング座標の不連続でミップ導関数が破綻しないよう、`SampleLevel`でLOD0を明示してサンプリングしています。画像全体を参照するため`MapOutputRectToInputRects`で入力矩形全体を要求し、サンプリング座標は入力境界の0.5ピクセル内側にクランプすることでバイリニアの端の参照を保護しています。除算の特異点は分割数とズームを`max`でガードし、`EffectImpl`側でもシェーダーが前提とする値域へクランプしています。定数バッファはC#側の構造体と順序、型、16バイト整列を一致させています。出力矩形は入力矩形と同一で、画像サイズは変化しません。
