### PR TITLE
映像エフェクト「ディザリング」を追加

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community.Shader/Dithering.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/Dithering.hlsl
@@ -3,13 +3,12 @@ SamplerState SourceSampler : register(s0);
 
 cbuffer Constants : register(b0)
 {
-    float4 inputBounds : packoffset(c0);
-    float levels : packoffset(c1.x);
-    float scale : packoffset(c1.y);
-    float strength : packoffset(c1.z);
-    int mode : packoffset(c1.w);
-    float4 darkColor : packoffset(c2);
-    float4 lightColor : packoffset(c3);
+    float levels : packoffset(c0.x);
+    float scale : packoffset(c0.y);
+    float strength : packoffset(c0.z);
+    int mode : packoffset(c0.w);
+    float4 darkColor : packoffset(c1);
+    float4 lightColor : packoffset(c2);
 };
 
 static const float3 LUMA = float3(0.299, 0.587, 0.114);
@@ -47,7 +46,7 @@ float4 main(
     if (source.a <= 0.0)
         return source;
 
-    float2 grid = floor((scenePosition.xy - inputBounds.xy) / max(scale, 1.0));
+    float2 grid = floor(scenePosition.xy / max(scale, 1.0));
     float threshold = lerp(0.5, BayerThreshold((uint2)(int2)grid), strength);
     float steps = max(levels - 1.0, 1.0);
 

--- a/YukkuriMovieMaker.Plugin.Community.Shader/Dithering.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/Dithering.hlsl
@@ -19,12 +19,12 @@ float BayerThreshold(uint2 cell)
     uint y = cell.y & 7u;
     uint xc = x ^ y;
     uint v = 0u;
-    v = (v << 1) | ((y >> 2) & 1u);
-    v = (v << 1) | ((xc >> 2) & 1u);
-    v = (v << 1) | ((y >> 1) & 1u);
-    v = (v << 1) | ((xc >> 1) & 1u);
-    v = (v << 1) | ((y >> 0) & 1u);
     v = (v << 1) | ((xc >> 0) & 1u);
+    v = (v << 1) | ((y >> 0) & 1u);
+    v = (v << 1) | ((xc >> 1) & 1u);
+    v = (v << 1) | ((y >> 1) & 1u);
+    v = (v << 1) | ((xc >> 2) & 1u);
+    v = (v << 1) | ((y >> 2) & 1u);
     return (float(v) + 0.5) / 64.0;
 }
 

--- a/YukkuriMovieMaker.Plugin.Community.Shader/Dithering.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/Dithering.hlsl
@@ -1,0 +1,74 @@
+Texture2D SourceTexture : register(t0);
+SamplerState SourceSampler : register(s0);
+
+cbuffer Constants : register(b0)
+{
+    float4 inputBounds : packoffset(c0);
+    float levels : packoffset(c1.x);
+    float scale : packoffset(c1.y);
+    float strength : packoffset(c1.z);
+    int mode : packoffset(c1.w);
+    float4 darkColor : packoffset(c2);
+    float4 lightColor : packoffset(c3);
+};
+
+static const float3 LUMA = float3(0.299, 0.587, 0.114);
+
+float BayerThreshold(uint2 cell)
+{
+    uint x = cell.x & 7u;
+    uint y = cell.y & 7u;
+    uint xc = x ^ y;
+    uint v = 0u;
+    v = (v << 1) | ((y >> 2) & 1u);
+    v = (v << 1) | ((xc >> 2) & 1u);
+    v = (v << 1) | ((y >> 1) & 1u);
+    v = (v << 1) | ((xc >> 1) & 1u);
+    v = (v << 1) | ((y >> 0) & 1u);
+    v = (v << 1) | ((xc >> 0) & 1u);
+    return (float(v) + 0.5) / 64.0;
+}
+
+float3 Quantize(float3 color, float threshold, float steps)
+{
+    float3 scaled = saturate(color) * steps;
+    float3 low = floor(scaled);
+    float3 fraction = scaled - low;
+    return (low + step(threshold, fraction)) / steps;
+}
+
+float4 main(
+    float4 position : SV_POSITION,
+    float4 scenePosition : SCENE_POSITION,
+    float4 uv0 : TEXCOORD0
+) : SV_TARGET
+{
+    float4 source = SourceTexture.SampleLevel(SourceSampler, uv0.xy, 0);
+    if (source.a <= 0.0)
+        return source;
+
+    float2 grid = floor((scenePosition.xy - inputBounds.xy) / max(scale, 1.0));
+    float threshold = lerp(0.5, BayerThreshold((uint2)(int2)grid), strength);
+    float steps = max(levels - 1.0, 1.0);
+
+    float3 straight = source.rgb / max(source.a, 1e-5);
+
+    float3 result;
+    if (mode == 2)
+    {
+        float luminance = dot(straight, LUMA);
+        float quantized = Quantize(luminance.xxx, threshold, steps).x;
+        result = lerp(darkColor.rgb, lightColor.rgb, quantized);
+    }
+    else if (mode == 1)
+    {
+        float luminance = dot(straight, LUMA);
+        result = Quantize(luminance.xxx, threshold, steps).x;
+    }
+    else
+    {
+        result = Quantize(straight, threshold, steps);
+    }
+
+    return float4(result * source.a, source.a);
+}

--- a/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj
@@ -425,6 +425,12 @@
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
     </FxCompile>
+	<FxCompile Include="Dithering.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+    </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Hash.hlsli" />

--- a/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj.filters
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj.filters
@@ -156,6 +156,9 @@
     <FxCompile Include="PuppetDeformationArap.hlsl">
       <Filter>ソース ファイル</Filter>
     </FxCompile>
+    <FxCompile Include="Dithering.hlsl">
+      <Filter>ソース ファイル</Filter>
+    </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Hash.hlsli">

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DitheringCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DitheringCustomEffect.cs
@@ -1,6 +1,5 @@
 using System.Numerics;
 using System.Runtime.InteropServices;
-using Vortice;
 using Vortice.Direct2D1;
 using YukkuriMovieMaker.Commons;
 using YukkuriMovieMaker.Player.Video;
@@ -41,7 +40,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Dithering
             private ConstantBuffer _cb;
 
             [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Levels)]
-            public float Levels { get => _cb.Levels; set { _cb.Levels = Math.Clamp(value, 2f, 256f); UpdateConstants(); } }
+            public float Levels { get => _cb.Levels; set { _cb.Levels = MathF.Round(Math.Clamp(value, 2f, 256f)); UpdateConstants(); } }
 
             [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Scale)]
             public float Scale { get => _cb.Scale; set { _cb.Scale = Math.Clamp(value, 1f, 4096f); UpdateConstants(); } }
@@ -77,26 +76,9 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Dithering
                 drawInformation?.SetPixelShaderConstantBuffer(_cb);
             }
 
-            public override void MapInputRectsToOutputRect(
-                RawRect[] inputRects,
-                RawRect[] inputOpaqueSubRects,
-                out RawRect outputRect,
-                out RawRect outputOpaqueSubRect)
-            {
-                base.MapInputRectsToOutputRect(inputRects, inputOpaqueSubRects, out outputRect, out outputOpaqueSubRect);
-
-                if (inputRects.Length > 0)
-                {
-                    var r = inputRects[0];
-                    _cb.InputBounds = new Vector4(r.Left, r.Top, r.Right, r.Bottom);
-                    UpdateConstants();
-                }
-            }
-
             [StructLayout(LayoutKind.Sequential)]
             private struct ConstantBuffer
             {
-                public Vector4 InputBounds;
                 public float Levels;
                 public float Scale;
                 public float Strength;

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DitheringCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DitheringCustomEffect.cs
@@ -1,0 +1,109 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+using Vortice;
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Commons;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Dithering
+{
+    public sealed class DitheringCustomEffect(IGraphicsDevicesAndContext devices) : D2D1CustomShaderEffectBase(Create<EffectImpl>(devices))
+    {
+        private enum PropertyIndex
+        {
+            Levels = 0,
+            Scale,
+            Strength,
+            Mode,
+            DarkR,
+            DarkG,
+            DarkB,
+            LightR,
+            LightG,
+            LightB,
+        }
+
+        public float Levels { set => SetValue((int)PropertyIndex.Levels, value); }
+        public float Scale { set => SetValue((int)PropertyIndex.Scale, value); }
+        public float Strength { set => SetValue((int)PropertyIndex.Strength, value); }
+        public int Mode { set => SetValue((int)PropertyIndex.Mode, value); }
+        public float DarkR { set => SetValue((int)PropertyIndex.DarkR, value); }
+        public float DarkG { set => SetValue((int)PropertyIndex.DarkG, value); }
+        public float DarkB { set => SetValue((int)PropertyIndex.DarkB, value); }
+        public float LightR { set => SetValue((int)PropertyIndex.LightR, value); }
+        public float LightG { set => SetValue((int)PropertyIndex.LightG, value); }
+        public float LightB { set => SetValue((int)PropertyIndex.LightB, value); }
+
+        [CustomEffect(1)]
+        private sealed class EffectImpl : D2D1CustomShaderEffectImplBase<EffectImpl>
+        {
+            private ConstantBuffer _cb;
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Levels)]
+            public float Levels { get => _cb.Levels; set { _cb.Levels = Math.Clamp(value, 2f, 256f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Scale)]
+            public float Scale { get => _cb.Scale; set { _cb.Scale = Math.Clamp(value, 1f, 4096f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Strength)]
+            public float Strength { get => _cb.Strength; set { _cb.Strength = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Int32, (int)PropertyIndex.Mode)]
+            public int Mode { get => _cb.Mode; set { _cb.Mode = Math.Clamp(value, 0, 2); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.DarkR)]
+            public float DarkR { get => _cb.DarkColor.X; set { _cb.DarkColor.X = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.DarkG)]
+            public float DarkG { get => _cb.DarkColor.Y; set { _cb.DarkColor.Y = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.DarkB)]
+            public float DarkB { get => _cb.DarkColor.Z; set { _cb.DarkColor.Z = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.LightR)]
+            public float LightR { get => _cb.LightColor.X; set { _cb.LightColor.X = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.LightG)]
+            public float LightG { get => _cb.LightColor.Y; set { _cb.LightColor.Y = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.LightB)]
+            public float LightB { get => _cb.LightColor.Z; set { _cb.LightColor.Z = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            public EffectImpl() : base(ShaderResourceUri.Get("Dithering")) { }
+
+            protected override void UpdateConstants()
+            {
+                drawInformation?.SetPixelShaderConstantBuffer(_cb);
+            }
+
+            public override void MapInputRectsToOutputRect(
+                RawRect[] inputRects,
+                RawRect[] inputOpaqueSubRects,
+                out RawRect outputRect,
+                out RawRect outputOpaqueSubRect)
+            {
+                base.MapInputRectsToOutputRect(inputRects, inputOpaqueSubRects, out outputRect, out outputOpaqueSubRect);
+
+                if (inputRects.Length > 0)
+                {
+                    var r = inputRects[0];
+                    _cb.InputBounds = new Vector4(r.Left, r.Top, r.Right, r.Bottom);
+                    UpdateConstants();
+                }
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            private struct ConstantBuffer
+            {
+                public Vector4 InputBounds;
+                public float Levels;
+                public float Scale;
+                public float Strength;
+                public int Mode;
+                public Vector4 DarkColor;
+                public Vector4 LightColor;
+            }
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DitheringEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DitheringEffect.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel.DataAnnotations;
+using System.Windows.Media;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Effects;
+using YukkuriMovieMaker.Project;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Dithering
+{
+    [VideoEffect(nameof(Texts.Dithering), [VideoEffectCategories.Filtering], [nameof(Texts.TagDithering), nameof(Texts.TagRetro), nameof(Texts.TagPixelArt)], IsAviUtlSupported = false, ResourceType = typeof(Texts))]
+    public sealed class DitheringEffect : VideoEffectBase
+    {
+        public override string Label => Texts.Dithering;
+
+        [Display(GroupName = nameof(Texts.Dithering), Name = nameof(Texts.Mode), Description = nameof(Texts.ModeDescription), Order = 0, ResourceType = typeof(Texts))]
+        [EnumComboBox]
+        public DitheringMode Mode
+        {
+            get => _mode;
+            set => Set(ref _mode, value);
+        }
+        private DitheringMode _mode = DitheringMode.Rgb;
+
+        [Display(GroupName = nameof(Texts.Dithering), Name = nameof(Texts.Levels), Description = nameof(Texts.LevelsDescription), Order = 1, ResourceType = typeof(Texts))]
+        [AnimationSlider("F0", "", 2, 16)]
+        public Animation Levels { get; } = new Animation(4, 2, 256);
+
+        [Display(GroupName = nameof(Texts.Dithering), Name = nameof(Texts.Scale), Description = nameof(Texts.ScaleDescription), Order = 2, ResourceType = typeof(Texts))]
+        [AnimationSlider("F0", "px", 1, 32)]
+        public Animation Scale { get; } = new Animation(1, 1, 512);
+
+        [Display(GroupName = nameof(Texts.Dithering), Name = nameof(Texts.Strength), Description = nameof(Texts.StrengthDescription), Order = 3, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 100)]
+        public Animation Strength { get; } = new Animation(100, 0, 100);
+
+        [Display(GroupName = nameof(Texts.Dithering), Name = nameof(Texts.DarkColor), Description = nameof(Texts.DarkColorDescription), Order = 4, ResourceType = typeof(Texts))]
+        [ColorPicker]
+        [DuotoneColorVisible]
+        public Color DarkColor
+        {
+            get => _darkColor;
+            set => Set(ref _darkColor, value);
+        }
+        private Color _darkColor = Color.FromArgb(255, 15, 56, 15);
+
+        [Display(GroupName = nameof(Texts.Dithering), Name = nameof(Texts.LightColor), Description = nameof(Texts.LightColorDescription), Order = 5, ResourceType = typeof(Texts))]
+        [ColorPicker]
+        [DuotoneColorVisible]
+        public Color LightColor
+        {
+            get => _lightColor;
+            set => Set(ref _lightColor, value);
+        }
+        private Color _lightColor = Color.FromArgb(255, 155, 188, 15);
+
+        [Display(GroupName = nameof(Texts.Dithering), Name = nameof(Texts.BlendMode), Description = nameof(Texts.BlendModeDescription), Order = 6, ResourceType = typeof(Texts))]
+        [EnumComboBox]
+        public Blend BlendMode
+        {
+            get => _blendMode;
+            set => Set(ref _blendMode, value);
+        }
+        private Blend _blendMode = Blend.Normal;
+
+        [Display(GroupName = nameof(Texts.Dithering), Name = nameof(Texts.Amount), Description = nameof(Texts.AmountDescription), Order = 7, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 100)]
+        public Animation Amount { get; } = new Animation(100, 0, 100);
+
+        private IAnimatable[]? _animatables;
+
+        public override IEnumerable<string> CreateExoVideoFilters(
+            int keyFrameIndex,
+            ExoOutputDescription exoOutputDescription) => [];
+
+        public override IVideoEffectProcessor CreateVideoEffect(IGraphicsDevicesAndContext devices)
+            => new DitheringEffectProcessor(devices, this);
+
+        protected override IEnumerable<IAnimatable> GetAnimatables()
+            => _animatables ??= [Levels, Scale, Strength, Amount];
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DitheringEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DitheringEffectProcessor.cs
@@ -1,0 +1,155 @@
+using System.Windows.Media;
+using Vortice.Direct2D1;
+using D2DEffects = Vortice.Direct2D1.Effects;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Player.Video.Effects;
+using YukkuriMovieMaker.Project;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Dithering
+{
+    internal sealed class DitheringEffectProcessor(
+        IGraphicsDevicesAndContext devices,
+        DitheringEffect item) : VideoEffectProcessorBase(devices)
+    {
+        private readonly DitheringEffect _item = item;
+
+        private DitheringCustomEffect? _dithering;
+        private D2DEffects.Composite? _compositeEffect;
+        private D2DEffects.Blend? _blendEffect;
+        private D2DEffects.CrossFade? _crossFadeEffect;
+
+        private bool _isFirst = true;
+        private double _levels;
+        private double _scale;
+        private double _strength;
+        private DitheringMode _mode;
+        private Color _darkColor;
+        private Color _lightColor;
+        private Project.Blend _blendMode;
+        private float _amount;
+
+        public override DrawDescription Update(EffectDescription effectDescription)
+        {
+            if (IsPassThroughEffect
+                || _dithering is null
+                || _compositeEffect is null
+                || _blendEffect is null
+                || _crossFadeEffect is null)
+                return effectDescription.DrawDescription;
+
+            var frame = effectDescription.ItemPosition.Frame;
+            var length = effectDescription.ItemDuration.Frame;
+            var fps = effectDescription.FPS;
+
+            var levels = _item.Levels.GetValue(frame, length, fps);
+            var scale = _item.Scale.GetValue(frame, length, fps);
+            var strength = _item.Strength.GetValue(frame, length, fps) / 100.0;
+            var mode = _item.Mode;
+            var darkColor = _item.DarkColor;
+            var lightColor = _item.LightColor;
+            var blendMode = _item.BlendMode;
+            var amount = (float)(_item.Amount.GetValue(frame, length, fps) / 100.0);
+
+            if (_isFirst || _levels != levels)
+                _dithering.Levels = (float)levels;
+            if (_isFirst || _scale != scale)
+                _dithering.Scale = (float)scale;
+            if (_isFirst || _strength != strength)
+                _dithering.Strength = (float)strength;
+            if (_isFirst || _mode != mode)
+                _dithering.Mode = (int)mode;
+            if (_isFirst || _darkColor != darkColor)
+            {
+                _dithering.DarkR = darkColor.R / 255f;
+                _dithering.DarkG = darkColor.G / 255f;
+                _dithering.DarkB = darkColor.B / 255f;
+            }
+            if (_isFirst || _lightColor != lightColor)
+            {
+                _dithering.LightR = lightColor.R / 255f;
+                _dithering.LightG = lightColor.G / 255f;
+                _dithering.LightB = lightColor.B / 255f;
+            }
+            if (_isFirst || _blendMode != blendMode)
+            {
+                if (blendMode.IsCompositionEffect())
+                {
+                    _compositeEffect.Mode = blendMode.ToD2DCompositionMode();
+                    using var composited = _compositeEffect.Output;
+                    _crossFadeEffect.SetInput(0, composited, true);
+                }
+                else
+                {
+                    _blendEffect.Mode = blendMode.ToD2DBlendMode();
+                    using var blended = _blendEffect.Output;
+                    _crossFadeEffect.SetInput(0, blended, true);
+                }
+            }
+            if (_isFirst || _amount != amount)
+                _crossFadeEffect.Weight = amount;
+
+            _levels = levels;
+            _scale = scale;
+            _strength = strength;
+            _mode = mode;
+            _darkColor = darkColor;
+            _lightColor = lightColor;
+            _blendMode = blendMode;
+            _amount = amount;
+            _isFirst = false;
+
+            return effectDescription.DrawDescription;
+        }
+
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            _dithering = new DitheringCustomEffect(devices);
+            if (!_dithering.IsEnabled)
+            {
+                _dithering.Dispose();
+                _dithering = null;
+                return null;
+            }
+            disposer.Collect(_dithering);
+
+            _compositeEffect = new D2DEffects.Composite(devices.DeviceContext) { InputCount = 2 };
+            disposer.Collect(_compositeEffect);
+            using (var ditheringOutput = _dithering.Output)
+                _compositeEffect.SetInput(1, ditheringOutput, true);
+
+            _blendEffect = new D2DEffects.Blend(devices.DeviceContext);
+            disposer.Collect(_blendEffect);
+            using (var ditheringOutput = _dithering.Output)
+                _blendEffect.SetInput(1, ditheringOutput, true);
+
+            _crossFadeEffect = new D2DEffects.CrossFade(devices.DeviceContext);
+            disposer.Collect(_crossFadeEffect);
+
+            var output = _crossFadeEffect.Output;
+            disposer.Collect(output);
+            return output;
+        }
+
+        protected override void setInput(ID2D1Image? input)
+        {
+            _dithering?.SetInput(0, input, true);
+            _compositeEffect?.SetInput(0, input, true);
+            _blendEffect?.SetInput(0, input, true);
+            _crossFadeEffect?.SetInput(1, input, true);
+        }
+
+        protected override void ClearEffectChain()
+        {
+            _dithering?.SetInput(0, null, true);
+            _compositeEffect?.SetInput(0, null, true);
+            _compositeEffect?.SetInput(1, null, true);
+            _blendEffect?.SetInput(0, null, true);
+            _blendEffect?.SetInput(1, null, true);
+            _crossFadeEffect?.SetInput(0, null, true);
+            _crossFadeEffect?.SetInput(1, null, true);
+            _isFirst = true;
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DitheringMode.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DitheringMode.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Dithering
+{
+    public enum DitheringMode
+    {
+        [Display(Name = nameof(Texts.ModeRgb), Description = nameof(Texts.ModeRgbDescription), ResourceType = typeof(Texts))]
+        Rgb,
+
+        [Display(Name = nameof(Texts.ModeGrayscale), Description = nameof(Texts.ModeGrayscaleDescription), ResourceType = typeof(Texts))]
+        Grayscale,
+
+        [Display(Name = nameof(Texts.ModeDuotone), Description = nameof(Texts.ModeDuotoneDescription), ResourceType = typeof(Texts))]
+        Duotone,
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DuotoneColorVisibleAttribute.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DuotoneColorVisibleAttribute.cs
@@ -1,0 +1,18 @@
+using System.Windows.Data;
+using YukkuriMovieMaker.ItemEditor;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Dithering
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    internal class DuotoneColorVisibleAttribute : Attribute, ICustomVisibilityAttribute2
+    {
+        public Binding GetBinding(object item, object propertyOwner)
+        {
+            return new Binding(nameof(DitheringEffect.Mode))
+            {
+                Source = item,
+                Converter = new DuotoneColorVisibleConverter()
+            };
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DuotoneColorVisibleConverter.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/DuotoneColorVisibleConverter.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Dithering
+{
+    internal class DuotoneColorVisibleConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value is DitheringMode.Duotone ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/Texts.cs
@@ -1,0 +1,10 @@
+using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.Dithering
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/Dithering/Texts.csv
@@ -1,0 +1,27 @@
+Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+Dithering,,ディザリング,Dithering,抖动,抖動,디더링,Tramado,التذبيب,Dithering
+TagDithering,,ディザ,Dither,抖动,抖動,디더,Tramado,تذبيب,Dither
+TagRetro,,レトロ,Retro,复古,復古,레트로,Retro,كلاسيكي,Retro
+TagPixelArt,,ドット絵,Pixel Art,像素画,像素畫,픽셀 아트,Pixel Art,فن البكسل,Pixel Art
+Mode,,モード,Mode,模式,模式,모드,Modo,الوضع,Mode
+ModeDescription,,ディザリングの色モード,Color mode of the dithering.,抖动的颜色模式。,抖動的顏色模式。,디더링의 색상 모드.,Modo de color del tramado.,وضع ألوان التذبيب.,Mode warna dithering.
+ModeRgb,,RGB,RGB,RGB,RGB,RGB,RGB,RGB,RGB
+ModeRgbDescription,,チャンネルごとに量子化します,Quantizes each channel independently.,对每个通道分别量子化。,對每個通道分別量子化。,채널별로 양자화합니다.,Cuantiza cada canal por separado.,يكمم كل قناة على حدة.,Mengkuantisasi setiap kanal secara terpisah.
+ModeGrayscale,,モノクロ,Monochrome,单色,單色,모노크롬,Monocromo,أحادي اللون,Monokrom
+ModeGrayscaleDescription,,輝度をモノクロで量子化します,Quantizes luminance in monochrome.,以单色量子化亮度。,以單色量子化亮度。,휘도를 모노크롬으로 양자화합니다.,Cuantiza la luminancia en monocromo.,يكمم الإضاءة بالأبيض والأسود.,Mengkuantisasi luminansi dalam monokrom.
+ModeDuotone,,デュオトーン,Duotone,双色调,雙色調,듀오톤,Duotono,ثنائي اللون,Duoton
+ModeDuotoneDescription,,輝度を2色の間に割り当てます,Maps luminance between two colors.,将亮度映射到两种颜色之间。,將亮度映射到兩種顏色之間。,휘도를 두 색상 사이에 매핑합니다.,Asigna la luminancia entre dos colores.,يوزع الإضاءة بين لونين.,Memetakan luminansi di antara dua warna.
+Levels,,階調数,Levels,色阶数,色階數,계조 수,Niveles,المستويات,Level
+LevelsDescription,,各チャンネルを量子化する階調の数,Number of tonal levels each channel is quantized to.,每个通道量化的色阶数量。,每個通道量化的色階數量。,각 채널을 양자화하는 계조 수.,Número de niveles tonales a los que se cuantiza cada canal.,عدد المستويات اللونية التي يتم تكميم كل قناة إليها.,Jumlah tingkat nada tempat setiap kanal dikuantisasi.
+Scale,,ドットサイズ,Dot Size,点大小,點大小,도트 크기,Tamaño de punto,حجم النقطة,Ukuran Titik
+ScaleDescription,,ディザパターン1マスの大きさ,Size of one cell of the dither pattern in pixels.,抖动图案单格的大小（像素）。,抖動圖案單格的大小（像素）。,디더 패턴 한 칸의 크기(픽셀).,Tamaño de una celda del patrón de tramado en píxeles.,حجم خلية واحدة من نمط التذبيب بالبكسل.,Ukuran satu sel pola dithering dalam piksel.
+Strength,,ディザ強度,Dither Strength,抖动强度,抖動強度,디더 강도,Intensidad de tramado,شدة التذبيب,Kekuatan Dithering
+StrengthDescription,,0でポスタリゼーション 100で完全なディザリングになります,At 0 it is posterization and at 100 it is full dithering.,0时为色调分离 100时为完全抖动。,0時為色調分離 100時為完全抖動。,0이면 포스터화 100이면 완전한 디더링이 됩니다.,En 0 es posterización y en 100 es tramado completo.,عند 0 يكون تحويلًا لونيًا وعند 100 يكون تذبيبًا كاملًا.,Pada 0 menjadi posterisasi dan pada 100 menjadi dithering penuh.
+DarkColor,,暗色,Dark Color,暗色,暗色,어두운 색,Color oscuro,اللون الداكن,Warna Gelap
+DarkColorDescription,,デュオトーンの暗部の色,Color for the dark tones in duotone.,双色调中暗部的颜色。,雙色調中暗部的顏色。,듀오톤에서 어두운 부분의 색.,Color de las zonas oscuras en duotono.,لون المناطق الداكنة في ثنائي اللون.,Warna bagian gelap pada duoton.
+LightColor,,明色,Light Color,亮色,亮色,밝은 색,Color claro,اللون الفاتح,Warna Terang
+LightColorDescription,,デュオトーンの明部の色,Color for the light tones in duotone.,双色调中亮部的颜色。,雙色調中亮部的顏色。,듀오톤에서 밝은 부분의 색.,Color de las zonas claras en duotono.,لون المناطق الفاتحة في ثنائي اللون.,Warna bagian terang pada duoton.
+BlendMode,,合成モード,Blend Mode,混合模式,混合模式,합성 모드,Modo de fusión,وضع المزج,Mode Campuran
+BlendModeDescription,,効果を元画像に合成する方法,How the effect is blended onto the source.,效果与原图像的混合方式。,效果與原圖像的混合方式。,효과를 원본에 합성하는 방식.,Cómo se fusiona el efecto sobre la fuente.,كيفية مزج التأثير على المصدر.,Cara efek dicampur ke sumber.
+Amount,,適用量,Amount,应用量,應用量,적용량,Cantidad,المقدار,Jumlah
+AmountDescription,,元画像と効果の合成比率,Blend ratio between the source and the effect.,原图像与效果的混合比例。,原圖像與效果的混合比例。,원본 이미지와 효과의 합성 비율.,Proporción de mezcla entre la fuente y el efecto.,نسبة المزج بين المصدر والتأثير.,Rasio pencampuran antara sumber dan efek.

--- a/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
+++ b/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
@@ -173,6 +173,7 @@
 	  <Resource Include="$(ShaderDirPath)AnisotropicKuwaharaTensor.cso" Link="Resources\Shader\AnisotropicKuwaharaTensor.cso" />
 	  <Resource Include="$(ShaderDirPath)AnisotropicKuwaharaTensorBlur.cso" Link="Resources\Shader\AnisotropicKuwaharaTensorBlur.cso" />
 	  <Resource Include="$(ShaderDirPath)AnisotropicKuwahara.cso" Link="Resources\Shader\AnisotropicKuwahara.cso" />
+	  <Resource Include="$(ShaderDirPath)Dithering.cso" Link="Resources\Shader\Dithering.cso" />
   </ItemGroup>
 
   <!-- internalsを参照するテスト（EdgeDetectionZeroStrengthOverlayTest等）はDEBUG限定のため、Releaseビルドには付与しない -->


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [x] このPRには1つの機能（または1つの修正）のみが含まれています
- [x] `YukkuriMovieMaker.dll`などYMM4本体の内部実装アセンブリを参照していません

## 概要
<!-- 変更内容を簡単に記載してください -->
新しい映像エフェクト「ディザリング」を追加します。
8x8のBayerマトリクスによる秩序ディザリングで階調を減色し、レトロやドット絵に向いた質感を作るエフェクトです。色モードとしてRGB、モノクロ、デュオトーンの3種類を持ち、結果を合成モードで元画像へ重ねられます。

## エフェクト本体
出力画素のシーン座標から整数セルを求め、そのセルに対してBayer閾値をビット演算で決定論的に生成します。求めた閾値で各成分を階調数の段階に量子化することでディザをかけます。ディザ強度は量子化の閾値を0.5とBayer閾値の間で補間する値で、0のときは単純なポスタリゼーション、100のときは完全な秩序ディザリングになります。ドットサイズはディザパターン1マスの拡大ピクセル数で、階調の粗密を空間的に調整します。

色モードは3種類です。RGBはチャンネルごとに独立して量子化します。モノクロは輝度を量子化して単色にします。デュオトーンは輝度を量子化した上で暗色と明色の2色の間へ割り当てるモードで、任意の2色による1bitレトロ表現を作れます。暗色と明色はデュオトーン選択時のみ表示されます。

合成モードは本体標準の合成方法をそのまま利用します。ディザリングの出力をBlendとCompositeで元画像へ合成し、CrossFadeの重みに適用量を接続します。これにより通常、乗算、スクリーン、オーバーレイなど本体と同じ全モードで結果を重ねられます。

パラメータのうち階調数、ドットサイズ、ディザ強度、適用量はアニメーションに対応します。モードと2色と合成モードは静的な設定項目です。乱数や時間に依存する要素は無く、出力はパラメータとシーン座標だけから決まるため、フレーム間でちらつきません。

D2Dカスタムエフェクトとしての実装上の要点は次のとおりです。ディザ本体は自ピクセルのみを参照する処理のため、出力矩形は入力矩形と同一で近傍サンプリングを行いません。Bayer閾値は`SCENE_POSITION`と入力矩形を基準に生成しており、補助データを追加の入力テクスチャで渡していないため、タイル分割境界のアーティファクトが発生しません。色はプリマルチプライドアルファをストレートへ戻して量子化し、出力時に乗算し直しています。定数バッファはC#側の構造体と順序、型、16バイト整列を一致させ、`EffectImpl`側で階調数、ドットサイズ、強度、モード、色をシェーダーが前提とする値域へクランプしています。
