### PR TITLE
映像エフェクト「光条」を追加

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community.Shader/CrossFilter.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/CrossFilter.hlsl
@@ -1,0 +1,103 @@
+Texture2D InputTexture : register(t0);
+SamplerState InputSampler : register(s0);
+
+cbuffer Constants : register(b0)
+{
+    float strength   : packoffset(c0.x);
+    float threshold  : packoffset(c0.y);
+    float lengthPx   : packoffset(c0.z);
+    float rayCount   : packoffset(c0.w);
+
+    float angleRad   : packoffset(c1.x);
+    float dispersion : packoffset(c1.y);
+    float thickness  : packoffset(c1.z);
+    int   lightOnly  : packoffset(c1.w);
+
+    float lightR     : packoffset(c2.x);
+    float lightG     : packoffset(c2.y);
+    float lightB     : packoffset(c2.z);
+    float pad0       : packoffset(c2.w);
+};
+
+#define SAMPLES 24
+
+float4 SampleInput(float2 uv)
+{
+    if (uv.x < 0.0f || uv.x > 1.0f || uv.y < 0.0f || uv.y > 1.0f)
+        return float4(0.0f, 0.0f, 0.0f, 0.0f);
+    return InputTexture.SampleLevel(InputSampler, uv, 0);
+}
+
+float4 main(
+    float4 pos      : SV_POSITION,
+    float4 posScene : SCENE_POSITION,
+    float4 uv0      : TEXCOORD0
+) : SV_Target
+{
+    float4 source = SampleInput(uv0.xy);
+    if (strength <= 0.0f && lightOnly == 0)
+        return source;
+
+    int rays = (int)clamp(rayCount, 1.0f, 16.0f);
+    float len = max(lengthPx, 1.0f);
+    float knee = max(1.0f - threshold, 0.05f);
+
+    float fR = 1.0f + 0.4f * dispersion;
+    float fB = max(1.0f - 0.35f * dispersion, 0.1f);
+
+    float3 acc = float3(0.0f, 0.0f, 0.0f);
+    float norm = 0.0f;
+
+    [loop]
+    for (int k = 0; k < rays; k++)
+    {
+        float ang = angleRad + 6.2831853f * (float)k / (float)rays;
+        float2 dir;
+        sincos(ang, dir.y, dir.x);
+        float2 perp = float2(-dir.y, dir.x);
+
+        [loop]
+        for (int i = 0; i < SAMPLES; i++)
+        {
+            float t = len * ((float)i + 0.5f) / (float)SAMPLES;
+            float2 basePx = posScene.xy + dir * t;
+
+            float4 s;
+            if (thickness > 0.25f)
+            {
+                s = SampleInput(uv0.xy + (basePx - posScene.xy) * uv0.zw) * 0.5f
+                  + SampleInput(uv0.xy + (basePx + perp * thickness - posScene.xy) * uv0.zw) * 0.25f
+                  + SampleInput(uv0.xy + (basePx - perp * thickness - posScene.xy) * uv0.zw) * 0.25f;
+            }
+            else
+            {
+                s = SampleInput(uv0.xy + (basePx - posScene.xy) * uv0.zw);
+            }
+
+            float lum = dot(s.rgb, float3(0.299f, 0.587f, 0.114f));
+            float mask = saturate((lum - threshold) / knee);
+            mask *= mask;
+
+            float u = 3.0f * t / len;
+            float wR = 1.0f / (1.0f + (u / fR) * (u / fR));
+            float wG = 1.0f / (1.0f + u * u);
+            float wB = 1.0f / (1.0f + (u / fB) * (u / fB));
+
+            acc += s.rgb * mask * float3(wR, wG, wB);
+            norm += wG;
+        }
+    }
+
+    float3 light = acc / max(norm, 1e-4f) * float3(lightR, lightG, lightB) * (strength * 3.0f);
+
+    if (lightOnly != 0)
+    {
+        float aL = saturate(max(light.r, max(light.g, light.b)));
+        return float4(min(light, float3(aL, aL, aL)), aL);
+    }
+
+    float4 result;
+    result.a = max(source.a, saturate(max(light.r, max(light.g, light.b))));
+    result.rgb = min(source.rgb + light, float3(result.a, result.a, result.a));
+    return result;
+}

--- a/YukkuriMovieMaker.Plugin.Community.Shader/CrossFilter.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/CrossFilter.hlsl
@@ -98,8 +98,9 @@ float4 main(
         return float4(min(light, float3(aL, aL, aL)), aL);
     }
 
+    float3 sum = source.rgb + light;
     float4 result;
-    result.a = max(source.a, saturate(max(light.r, max(light.g, light.b))));
-    result.rgb = min(source.rgb + light, float3(result.a, result.a, result.a));
+    result.a = max(source.a, saturate(max(sum.r, max(sum.g, sum.b))));
+    result.rgb = min(sum, float3(result.a, result.a, result.a));
     return result;
 }

--- a/YukkuriMovieMaker.Plugin.Community.Shader/CrossFilter.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/CrossFilter.hlsl
@@ -16,10 +16,10 @@ cbuffer Constants : register(b0)
     float lightR     : packoffset(c2.x);
     float lightG     : packoffset(c2.y);
     float lightB     : packoffset(c2.z);
-    float pad0       : packoffset(c2.w);
+    float sampleCount : packoffset(c2.w);
 };
 
-#define SAMPLES 24
+#define MAX_SAMPLES 64
 
 float4 SampleInput(float2 uv)
 {
@@ -39,6 +39,7 @@ float4 main(
         return source;
 
     int rays = (int)clamp(rayCount, 1.0f, 16.0f);
+    int samples = (int)clamp(sampleCount, 1.0f, (float)MAX_SAMPLES);
     float len = max(lengthPx, 1.0f);
     float knee = max(1.0f - threshold, 0.05f);
 
@@ -57,9 +58,9 @@ float4 main(
         float2 perp = float2(-dir.y, dir.x);
 
         [loop]
-        for (int i = 0; i < SAMPLES; i++)
+        for (int i = 0; i < samples; i++)
         {
-            float t = len * ((float)i + 0.5f) / (float)SAMPLES;
+            float t = len * ((float)i + 0.5f) / (float)samples;
             float2 basePx = posScene.xy + dir * t;
 
             float4 s;

--- a/YukkuriMovieMaker.Plugin.Community.Shader/CrossFilter.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/CrossFilter.hlsl
@@ -84,7 +84,8 @@ float4 main(
             float wB = 1.0f / (1.0f + (u / fB) * (u / fB));
 
             acc += s.rgb * mask * float3(wR, wG, wB);
-            norm += wG;
+            if (k == 0)
+                norm += wG;
         }
     }
 

--- a/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj
@@ -455,6 +455,12 @@
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
     </FxCompile>
+	<FxCompile Include="CrossFilter.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+    </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Hash.hlsli" />

--- a/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj.filters
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj.filters
@@ -171,6 +171,9 @@
     <FxCompile Include="VectorFieldWarp.hlsl">
       <Filter>ソース ファイル</Filter>
     </FxCompile>
+    <FxCompile Include="CrossFilter.hlsl">
+      <Filter>ソース ファイル</Filter>
+    </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Hash.hlsli">

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterCustomEffect.cs
@@ -1,0 +1,154 @@
+using System.Runtime.InteropServices;
+using Vortice;
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Commons;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
+{
+    internal sealed class CrossFilterCustomEffect(IGraphicsDevicesAndContext devices) : D2D1CustomShaderEffectBase(Create<EffectImpl>(devices))
+    {
+        private enum PropertyIndex
+        {
+            Strength = 0,
+            Threshold,
+            Length,
+            RayCount,
+            Angle,
+            Dispersion,
+            Thickness,
+            LightOnly,
+            LightR,
+            LightG,
+            LightB,
+        }
+
+        public float Strength { set => SetValue((int)PropertyIndex.Strength, value); }
+        public float Threshold { set => SetValue((int)PropertyIndex.Threshold, value); }
+        public float Length { set => SetValue((int)PropertyIndex.Length, value); }
+        public float RayCount { set => SetValue((int)PropertyIndex.RayCount, value); }
+        public float Angle { set => SetValue((int)PropertyIndex.Angle, value); }
+        public float Dispersion { set => SetValue((int)PropertyIndex.Dispersion, value); }
+        public float Thickness { set => SetValue((int)PropertyIndex.Thickness, value); }
+        public int LightOnly { set => SetValue((int)PropertyIndex.LightOnly, value); }
+        public float LightR { set => SetValue((int)PropertyIndex.LightR, value); }
+        public float LightG { set => SetValue((int)PropertyIndex.LightG, value); }
+        public float LightB { set => SetValue((int)PropertyIndex.LightB, value); }
+
+        [CustomEffect(1)]
+        private sealed class EffectImpl : D2D1CustomShaderEffectImplBase<EffectImpl>
+        {
+            private ConstantBuffer _cb;
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Strength)]
+            public float Strength { get => _cb.Strength; set { _cb.Strength = Math.Clamp(value, 0f, 20f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Threshold)]
+            public float Threshold { get => _cb.Threshold; set { _cb.Threshold = Math.Clamp(value, 0f, 0.999f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Length)]
+            public float Length { get => _cb.Length; set { _cb.Length = Math.Clamp(value, 0f, 2000f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.RayCount)]
+            public float RayCount { get => _cb.RayCount; set { _cb.RayCount = Math.Clamp(value, 1f, 16f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Angle)]
+            public float Angle { get => _cb.Angle; set { _cb.Angle = value; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Dispersion)]
+            public float Dispersion { get => _cb.Dispersion; set { _cb.Dispersion = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Thickness)]
+            public float Thickness { get => _cb.Thickness; set { _cb.Thickness = Math.Clamp(value, 0f, 50f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Int32, (int)PropertyIndex.LightOnly)]
+            public int LightOnly { get => _cb.LightOnly; set { _cb.LightOnly = value != 0 ? 1 : 0; UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.LightR)]
+            public float LightR { get => _cb.LightR; set { _cb.LightR = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.LightG)]
+            public float LightG { get => _cb.LightG; set { _cb.LightG = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.LightB)]
+            public float LightB { get => _cb.LightB; set { _cb.LightB = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            public EffectImpl() : base(ShaderResourceUri.Get("CrossFilter"))
+            {
+                _cb.Strength = 1f;
+                _cb.Threshold = 0.6f;
+                _cb.Length = 80f;
+                _cb.RayCount = 4f;
+                _cb.LightR = 1f;
+                _cb.LightG = 1f;
+                _cb.LightB = 1f;
+            }
+
+            protected override void UpdateConstants()
+            {
+                drawInformation?.SetPixelShaderConstantBuffer(_cb);
+            }
+
+            private int Padding()
+            {
+                var margin = Math.Min(Math.Max(_cb.Length, 0f) + Math.Max(_cb.Thickness, 0f) + 2f, 4096f);
+                return (int)Math.Ceiling(margin);
+            }
+
+            public override void MapInputRectsToOutputRect(RawRect[] inputRects, RawRect[] inputOpaqueSubRects, out RawRect outputRect, out RawRect outputOpaqueSubRect)
+            {
+                inputRect = ClampInputRect(inputRects[0]);
+                if (inputRect.Right <= inputRect.Left || inputRect.Bottom <= inputRect.Top)
+                {
+                    outputRect = inputRect;
+                    outputOpaqueSubRect = default;
+                    return;
+                }
+
+                var padding = Padding();
+                outputRect = new RawRect(
+                    inputRect.Left - padding,
+                    inputRect.Top - padding,
+                    inputRect.Right + padding,
+                    inputRect.Bottom + padding);
+                outputOpaqueSubRect = default;
+            }
+
+            public override void MapOutputRectToInputRects(RawRect outputRect, RawRect[] inputRects)
+            {
+                if (inputRect.Right <= inputRect.Left || inputRect.Bottom <= inputRect.Top)
+                {
+                    inputRects[0] = inputRect;
+                    return;
+                }
+
+                var padding = Padding();
+                inputRects[0] = new RawRect(
+                    Saturate((long)outputRect.Left - padding),
+                    Saturate((long)outputRect.Top - padding),
+                    Saturate((long)outputRect.Right + padding),
+                    Saturate((long)outputRect.Bottom + padding));
+            }
+
+            private static int Saturate(long value) => (int)Math.Clamp(value, int.MinValue, int.MaxValue);
+
+            [StructLayout(LayoutKind.Sequential)]
+            private struct ConstantBuffer
+            {
+                public float Strength;
+                public float Threshold;
+                public float Length;
+                public float RayCount;
+                public float Angle;
+                public float Dispersion;
+                public float Thickness;
+                public int LightOnly;
+                public float LightR;
+                public float LightG;
+                public float LightB;
+                public float Pad0;
+            }
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterCustomEffect.cs
@@ -22,6 +22,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
             LightR,
             LightG,
             LightB,
+            Samples,
         }
 
         public float Strength { set => SetValue((int)PropertyIndex.Strength, value); }
@@ -35,6 +36,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
         public float LightR { set => SetValue((int)PropertyIndex.LightR, value); }
         public float LightG { set => SetValue((int)PropertyIndex.LightG, value); }
         public float LightB { set => SetValue((int)PropertyIndex.LightB, value); }
+        public float Samples { set => SetValue((int)PropertyIndex.Samples, value); }
 
         [CustomEffect(1)]
         private sealed class EffectImpl : D2D1CustomShaderEffectImplBase<EffectImpl>
@@ -74,12 +76,16 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
             [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.LightB)]
             public float LightB { get => _cb.LightB; set { _cb.LightB = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
 
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Samples)]
+            public float Samples { get => _cb.Samples; set { _cb.Samples = Math.Clamp(value, 1f, 64f); UpdateConstants(); } }
+
             public EffectImpl() : base(ShaderResourceUri.Get("CrossFilter"))
             {
                 _cb.Strength = 1f;
                 _cb.Threshold = 0.6f;
                 _cb.Length = 80f;
                 _cb.RayCount = 4f;
+                _cb.Samples = 24f;
                 _cb.LightR = 1f;
                 _cb.LightG = 1f;
                 _cb.LightB = 1f;
@@ -147,7 +153,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
                 public float LightR;
                 public float LightG;
                 public float LightB;
-                public float Pad0;
+                public float Samples;
             }
         }
     }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterEffect.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel.DataAnnotations;
+using System.Windows.Media;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
+{
+    [VideoEffect(nameof(Texts.CrossFilterEffectName), [VideoEffectCategories.Decoration], [nameof(Texts.TagCrossFilter), nameof(Texts.TagSparkle), nameof(Texts.TagLightStreak)], IsAviUtlSupported = false, ResourceType = typeof(Texts))]
+    public sealed class CrossFilterEffect : VideoEffectBase
+    {
+        public override string Label => Texts.CrossFilterEffectName;
+
+        [Display(GroupName = nameof(Texts.CrossFilterEffectName), Name = nameof(Texts.CrossFilterStrength), Description = nameof(Texts.CrossFilterStrengthDescription), Order = 0, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 500)]
+        public Animation Strength { get; } = new Animation(100, 0, 1000);
+
+        [Display(GroupName = nameof(Texts.CrossFilterEffectName), Name = nameof(Texts.CrossFilterThreshold), Description = nameof(Texts.CrossFilterThresholdDescription), Order = 1, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 100)]
+        public Animation Threshold { get; } = new Animation(60, 0, 100);
+
+        [Display(GroupName = nameof(Texts.CrossFilterEffectName), Name = nameof(Texts.CrossFilterLength), Description = nameof(Texts.CrossFilterLengthDescription), Order = 2, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", 0, 300)]
+        public Animation Length { get; } = new Animation(80, 0, 1000);
+
+        [Display(GroupName = nameof(Texts.CrossFilterEffectName), Name = nameof(Texts.CrossFilterRayCount), Description = nameof(Texts.CrossFilterRayCountDescription), Order = 3, ResourceType = typeof(Texts))]
+        [AnimationSlider("F0", "", 1, 16)]
+        public Animation RayCount { get; } = new Animation(4, 1, 16);
+
+        [Display(GroupName = nameof(Texts.CrossFilterEffectName), Name = nameof(Texts.CrossFilterAngle), Description = nameof(Texts.CrossFilterAngleDescription), Order = 4, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "°", 0, 360)]
+        public Animation Angle { get; } = new Animation(45, -36000, 36000);
+
+        [Display(GroupName = nameof(Texts.CrossFilterEffectName), Name = nameof(Texts.CrossFilterThickness), Description = nameof(Texts.CrossFilterThicknessDescription), Order = 5, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", 0, 10)]
+        public Animation Thickness { get; } = new Animation(1, 0, 50);
+
+        [Display(GroupName = nameof(Texts.CrossFilterEffectName), Name = nameof(Texts.CrossFilterDispersion), Description = nameof(Texts.CrossFilterDispersionDescription), Order = 6, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 0, 100)]
+        public Animation Dispersion { get; } = new Animation(30, 0, 100);
+
+        [Display(GroupName = nameof(Texts.CrossFilterEffectName), Name = nameof(Texts.CrossFilterLightColor), Description = nameof(Texts.CrossFilterLightColorDescription), Order = 7, ResourceType = typeof(Texts))]
+        [ColorPicker]
+        public Color LightColor
+        {
+            get => _lightColor;
+            set => Set(ref _lightColor, value);
+        }
+        private Color _lightColor = Colors.White;
+
+        [Display(GroupName = nameof(Texts.CrossFilterEffectName), Name = nameof(Texts.CrossFilterLightOnly), Description = nameof(Texts.CrossFilterLightOnlyDescription), Order = 8, ResourceType = typeof(Texts))]
+        [ToggleSlider]
+        public bool LightOnly
+        {
+            get => _lightOnly;
+            set => Set(ref _lightOnly, value);
+        }
+        private bool _lightOnly = false;
+
+        private IAnimatable[]? _animatables;
+
+        public override IEnumerable<string> CreateExoVideoFilters(int keyFrameIndex, ExoOutputDescription exoOutputDescription) => [];
+
+        public override IVideoEffectProcessor CreateVideoEffect(IGraphicsDevicesAndContext devices)
+            => new CrossFilterEffectProcessor(devices, this);
+
+        protected override IEnumerable<IAnimatable> GetAnimatables()
+            => _animatables ??= [Strength, Threshold, Length, RayCount, Angle, Thickness, Dispersion];
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterEffect.cs
@@ -50,7 +50,11 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
         }
         private Color _lightColor = Colors.White;
 
-        [Display(GroupName = nameof(Texts.CrossFilterEffectName), Name = nameof(Texts.CrossFilterLightOnly), Description = nameof(Texts.CrossFilterLightOnlyDescription), Order = 8, ResourceType = typeof(Texts))]
+        [Display(GroupName = nameof(Texts.CrossFilterEffectName), Name = nameof(Texts.CrossFilterSamples), Description = nameof(Texts.CrossFilterSamplesDescription), Order = 8, ResourceType = typeof(Texts))]
+        [AnimationSlider("F0", "", 1, 64)]
+        public Animation Samples { get; } = new Animation(24, 1, 64);
+
+        [Display(GroupName = nameof(Texts.CrossFilterEffectName), Name = nameof(Texts.CrossFilterLightOnly), Description = nameof(Texts.CrossFilterLightOnlyDescription), Order = 9, ResourceType = typeof(Texts))]
         [ToggleSlider]
         public bool LightOnly
         {
@@ -67,6 +71,6 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
             => new CrossFilterEffectProcessor(devices, this);
 
         protected override IEnumerable<IAnimatable> GetAnimatables()
-            => _animatables ??= [Strength, Threshold, Length, RayCount, Angle, Thickness, Dispersion];
+            => _animatables ??= [Strength, Threshold, Length, RayCount, Angle, Thickness, Dispersion, Samples];
     }
 }

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterEffect.cs
@@ -8,7 +8,7 @@ using YukkuriMovieMaker.Plugin.Effects;
 
 namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
 {
-    [VideoEffect(nameof(Texts.CrossFilterEffectName), [VideoEffectCategories.Decoration], [nameof(Texts.TagCrossFilter), nameof(Texts.TagSparkle), nameof(Texts.TagLightStreak)], IsAviUtlSupported = false, ResourceType = typeof(Texts))]
+    [VideoEffect(nameof(Texts.CrossFilterEffectName), [VideoEffectCategories.Drawing], [nameof(Texts.TagCrossFilter), nameof(Texts.TagSparkle), nameof(Texts.TagLightStreak)], IsAviUtlSupported = false, ResourceType = typeof(Texts))]
     public sealed class CrossFilterEffect : VideoEffectBase
     {
         public override string Label => Texts.CrossFilterEffectName;

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterEffectProcessor.cs
@@ -34,6 +34,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
                 (float)(_item.Angle.GetValue(frame, length, fps) * Math.PI / 180.0),
                 (float)(_item.Dispersion.GetValue(frame, length, fps) / 100.0),
                 (float)_item.Thickness.GetValue(frame, length, fps),
+                (float)Math.Round(_item.Samples.GetValue(frame, length, fps)),
                 lightColor.R / 255f,
                 lightColor.G / 255f,
                 lightColor.B / 255f,
@@ -53,6 +54,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
                 _effect.Dispersion = parameters.Dispersion;
             if (_isFirst || _parameters.Thickness != parameters.Thickness)
                 _effect.Thickness = parameters.Thickness;
+            if (_isFirst || _parameters.Samples != parameters.Samples)
+                _effect.Samples = parameters.Samples;
             if (_isFirst || _parameters.LightR != parameters.LightR)
                 _effect.LightR = parameters.LightR;
             if (_isFirst || _parameters.LightG != parameters.LightG)
@@ -103,6 +106,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
             float Angle,
             float Dispersion,
             float Thickness,
+            float Samples,
             float LightR,
             float LightG,
             float LightB,

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterEffectProcessor.cs
@@ -25,6 +25,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
             var fps = effectDescription.FPS;
 
             var lightColor = _item.LightColor;
+            var lightAlpha = lightColor.A / 255f;
 
             var parameters = new Parameters(
                 (float)(_item.Strength.GetValue(frame, length, fps) / 100.0),
@@ -35,9 +36,9 @@ namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
                 (float)(_item.Dispersion.GetValue(frame, length, fps) / 100.0),
                 (float)_item.Thickness.GetValue(frame, length, fps),
                 (float)Math.Round(_item.Samples.GetValue(frame, length, fps)),
-                lightColor.R / 255f,
-                lightColor.G / 255f,
-                lightColor.B / 255f,
+                lightColor.R / 255f * lightAlpha,
+                lightColor.G / 255f * lightAlpha,
+                lightColor.B / 255f * lightAlpha,
                 _item.LightOnly ? 1 : 0);
 
             if (_isFirst || _parameters.Strength != parameters.Strength)

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterEffectProcessor.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/CrossFilterEffectProcessor.cs
@@ -1,0 +1,111 @@
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Player.Video.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
+{
+    internal sealed class CrossFilterEffectProcessor(
+        IGraphicsDevicesAndContext devices,
+        CrossFilterEffect item) : VideoEffectProcessorBase(devices)
+    {
+        private readonly CrossFilterEffect _item = item;
+        private CrossFilterCustomEffect? _effect;
+
+        private bool _isFirst = true;
+        private Parameters _parameters;
+
+        public override DrawDescription Update(EffectDescription effectDescription)
+        {
+            if (IsPassThroughEffect || _effect is null)
+                return effectDescription.DrawDescription;
+
+            var frame = effectDescription.ItemPosition.Frame;
+            var length = effectDescription.ItemDuration.Frame;
+            var fps = effectDescription.FPS;
+
+            var lightColor = _item.LightColor;
+
+            var parameters = new Parameters(
+                (float)(_item.Strength.GetValue(frame, length, fps) / 100.0),
+                (float)(_item.Threshold.GetValue(frame, length, fps) / 100.0),
+                (float)_item.Length.GetValue(frame, length, fps),
+                (float)Math.Round(_item.RayCount.GetValue(frame, length, fps)),
+                (float)(_item.Angle.GetValue(frame, length, fps) * Math.PI / 180.0),
+                (float)(_item.Dispersion.GetValue(frame, length, fps) / 100.0),
+                (float)_item.Thickness.GetValue(frame, length, fps),
+                lightColor.R / 255f,
+                lightColor.G / 255f,
+                lightColor.B / 255f,
+                _item.LightOnly ? 1 : 0);
+
+            if (_isFirst || _parameters.Strength != parameters.Strength)
+                _effect.Strength = parameters.Strength;
+            if (_isFirst || _parameters.Threshold != parameters.Threshold)
+                _effect.Threshold = parameters.Threshold;
+            if (_isFirst || _parameters.Length != parameters.Length)
+                _effect.Length = parameters.Length;
+            if (_isFirst || _parameters.RayCount != parameters.RayCount)
+                _effect.RayCount = parameters.RayCount;
+            if (_isFirst || _parameters.Angle != parameters.Angle)
+                _effect.Angle = parameters.Angle;
+            if (_isFirst || _parameters.Dispersion != parameters.Dispersion)
+                _effect.Dispersion = parameters.Dispersion;
+            if (_isFirst || _parameters.Thickness != parameters.Thickness)
+                _effect.Thickness = parameters.Thickness;
+            if (_isFirst || _parameters.LightR != parameters.LightR)
+                _effect.LightR = parameters.LightR;
+            if (_isFirst || _parameters.LightG != parameters.LightG)
+                _effect.LightG = parameters.LightG;
+            if (_isFirst || _parameters.LightB != parameters.LightB)
+                _effect.LightB = parameters.LightB;
+            if (_isFirst || _parameters.LightOnly != parameters.LightOnly)
+                _effect.LightOnly = parameters.LightOnly;
+
+            _parameters = parameters;
+            _isFirst = false;
+
+            return effectDescription.DrawDescription;
+        }
+
+        protected override ID2D1Image? CreateEffect(IGraphicsDevicesAndContext devices)
+        {
+            _effect = new CrossFilterCustomEffect(devices);
+            if (!_effect.IsEnabled)
+            {
+                _effect.Dispose();
+                _effect = null;
+                return null;
+            }
+            disposer.Collect(_effect);
+
+            var output = _effect.Output;
+            disposer.Collect(output);
+            return output;
+        }
+
+        protected override void setInput(ID2D1Image? input)
+        {
+            _effect?.SetInput(0, input, true);
+        }
+
+        protected override void ClearEffectChain()
+        {
+            _effect?.SetInput(0, null, true);
+            _isFirst = true;
+        }
+
+        private readonly record struct Parameters(
+            float Strength,
+            float Threshold,
+            float Length,
+            float RayCount,
+            float Angle,
+            float Dispersion,
+            float Thickness,
+            float LightR,
+            float LightG,
+            float LightB,
+            int LightOnly);
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/Texts.cs
@@ -1,0 +1,10 @@
+using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Effect.Video.CrossFilter
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/Texts.csv
@@ -14,6 +14,8 @@ CrossFilterThickness,,太さ,Thickness,粗细,粗細,두께,Grosor,السماك�
 CrossFilterThicknessDescription,,光の筋の太さ,Thickness of the light streaks,光芒的粗细,光芒的粗細,빛줄기의 두께,Grosor de los rayos de luz,سماكة خيوط الضوء,Ketebalan garis cahaya
 CrossFilterDispersion,,分散,Dispersion,色散,色散,분산,Dispersión,التشتت,Dispersi
 CrossFilterDispersionDescription,,波長による回折差。筋の先端が虹色に色づきます,Wavelength-dependent diffraction. Tints the streak tips with rainbow colors,波长引起的衍射差。使光芒尖端呈现彩虹色,波長引起的繞射差。使光芒尖端呈現彩虹色,파장에 따른 회절 차이. 줄기 끝이 무지개색으로 물듭니다,Difracción dependiente de la longitud de onda. Tiñe las puntas de los rayos con colores de arcoíris,حيود يعتمد على الطول الموجي. يلوّن أطراف الخيوط بألوان قوس قزح,Difraksi bergantung panjang gelombang. Mewarnai ujung garis dengan warna pelangi
+CrossFilterSamples,,サンプル数,Samples,采样数,取樣數,샘플 수,Muestras,عدد العينات,Jumlah sampel
+CrossFilterSamplesDescription,,光の筋のサンプル数 (多いほど高品質),Number of streak samples (more = higher quality),光芒采样数（越多越高质量）,光芒取樣數（越多品質越高）,빛줄기 샘플 수 (많을수록 품질 높음),Número de muestras de los rayos (más = mayor calidad),عدد عينات الخيوط (أكثر = جودة أعلى),Jumlah sampel garis cahaya (lebih banyak = kualitas lebih tinggi)
 CrossFilterLightColor,,光の色,Light color,光的颜色,光的顏色,빛의 색,Color de la luz,لون الضوء,Warna cahaya
 CrossFilterLightColorDescription,,光の筋に乗せる色,Tint applied to the light streaks,附加到光芒上的颜色,附加到光芒上的顏色,빛줄기에 입히는 색,Tinte aplicado a los rayos de luz,اللون المطبق على خيوط الضوء,Warna yang diterapkan pada garis cahaya
 CrossFilterLightOnly,,光のみ表示,Light only,仅显示光,僅顯示光,빛만 표시,Solo luz,الضوء فقط,Hanya cahaya

--- a/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Effect/Video/CrossFilter/Texts.csv
@@ -1,0 +1,23 @@
+Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+CrossFilterEffectName,,光条,Cross Filter,光芒,光芒,크로스 필터,Filtro cruzado,شعاع النجمة,Filter silang
+CrossFilterStrength,,強度,Strength,强度,強度,강도,Intensidad,القوة,Kekuatan
+CrossFilterStrengthDescription,,光の筋の明るさ,Brightness of the light streaks,光芒的亮度,光芒的亮度,빛줄기의 밝기,Brillo de los rayos de luz,سطوع خيوط الضوء,Kecerahan garis cahaya
+CrossFilterThreshold,,しきい値,Threshold,阈值,閾值,임계값,Umbral,العتبة,Ambang
+CrossFilterThresholdDescription,,光の筋が発生する最小の明るさ,Minimum brightness that produces light streaks,产生光芒的最小亮度,產生光芒的最小亮度,빛줄기가 발생하는 최소 밝기,Brillo mínimo que produce rayos de luz,أدنى سطوع ينتج خيوط الضوء,Kecerahan minimum yang menghasilkan garis cahaya
+CrossFilterLength,,長さ,Length,长度,長度,길이,Longitud,الطول,Panjang
+CrossFilterLengthDescription,,光の筋が伸びる距離,Distance the light streaks extend,光芒延伸的距离,光芒延伸的距離,빛줄기가 뻗는 거리,Distancia a la que se extienden los rayos,المسافة التي تمتد إليها خيوط الضوء,Jarak perpanjangan garis cahaya
+CrossFilterRayCount,,本数,Ray count,光芒数量,光芒數量,줄기 수,Número de rayos,عدد الأشعة,Jumlah sinar
+CrossFilterRayCountDescription,,1つの光源から伸びる筋の数,Number of streaks radiating from each highlight,从每个光源延伸的光芒数量,從每個光源延伸的光芒數量,하나의 광원에서 뻗는 줄기의 수,Número de rayos que irradian de cada punto de luz,عدد الخيوط المنبعثة من كل نقطة ضوء,Jumlah garis yang memancar dari tiap titik cahaya
+CrossFilterAngle,,角度,Angle,角度,角度,각도,Ángulo,الزاوية,Sudut
+CrossFilterAngleDescription,,光の筋全体の回転角度,Rotation angle of the streak pattern,光芒整体的旋转角度,光芒整體的旋轉角度,빛줄기 전체의 회전 각도,Ángulo de rotación del patrón de rayos,زاوية دوران نمط الأشعة,Sudut rotasi pola garis cahaya
+CrossFilterThickness,,太さ,Thickness,粗细,粗細,두께,Grosor,السماكة,Ketebalan
+CrossFilterThicknessDescription,,光の筋の太さ,Thickness of the light streaks,光芒的粗细,光芒的粗細,빛줄기의 두께,Grosor de los rayos de luz,سماكة خيوط الضوء,Ketebalan garis cahaya
+CrossFilterDispersion,,分散,Dispersion,色散,色散,분산,Dispersión,التشتت,Dispersi
+CrossFilterDispersionDescription,,波長による回折差。筋の先端が虹色に色づきます,Wavelength-dependent diffraction. Tints the streak tips with rainbow colors,波长引起的衍射差。使光芒尖端呈现彩虹色,波長引起的繞射差。使光芒尖端呈現彩虹色,파장에 따른 회절 차이. 줄기 끝이 무지개색으로 물듭니다,Difracción dependiente de la longitud de onda. Tiñe las puntas de los rayos con colores de arcoíris,حيود يعتمد على الطول الموجي. يلوّن أطراف الخيوط بألوان قوس قزح,Difraksi bergantung panjang gelombang. Mewarnai ujung garis dengan warna pelangi
+CrossFilterLightColor,,光の色,Light color,光的颜色,光的顏色,빛의 색,Color de la luz,لون الضوء,Warna cahaya
+CrossFilterLightColorDescription,,光の筋に乗せる色,Tint applied to the light streaks,附加到光芒上的颜色,附加到光芒上的顏色,빛줄기에 입히는 색,Tinte aplicado a los rayos de luz,اللون المطبق على خيوط الضوء,Warna yang diterapkan pada garis cahaya
+CrossFilterLightOnly,,光のみ表示,Light only,仅显示光,僅顯示光,빛만 표시,Solo luz,الضوء فقط,Hanya cahaya
+CrossFilterLightOnlyDescription,,映像を消して光の筋だけを出力します,Outputs only the light streaks without the image,隐藏图像仅输出光芒,隱藏圖像僅輸出光芒,영상을 지우고 빛줄기만 출력합니다,Genera solo los rayos de luz sin la imagen,يُخرج خيوط الضوء فقط دون الصورة,Hanya mengeluarkan garis cahaya tanpa gambar
+TagCrossFilter,,クロスフィルター,cross filter,十字滤镜,十字濾鏡,크로스 필터,filtro cruzado,مرشح متقاطع,filter silang
+TagSparkle,,きらめき,sparkle,闪耀,閃耀,반짝임,destello,بريق,kilau
+TagLightStreak,,光条,light streak,光芒,光芒,빛줄기,rayo de luz,خيط ضوء,garis cahaya

--- a/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
+++ b/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
@@ -178,6 +178,7 @@
     <Resource Include="$(ShaderDirPath)FacetedGlass.cso" Link="Resources\Shader\FacetedGlass.cso" />
     <Resource Include="$(ShaderDirPath)Dithering.cso" Link="Resources\Shader\Dithering.cso" />
     <Resource Include="$(ShaderDirPath)VectorFieldWarp.cso" Link="Resources\Shader\VectorFieldWarp.cso" />
+    <Resource Include="$(ShaderDirPath)CrossFilter.cso" Link="Resources\Shader\CrossFilter.cso" />
   </ItemGroup>
 
   <!-- internalsを参照するテスト（EdgeDetectionZeroStrengthOverlayTest等）はDEBUG限定のため、Releaseビルドには付与しない -->


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [x] このPRには1つの機能（または1つの修正）のみが含まれています
- [x] `YukkuriMovieMaker.dll`などYMM4本体の内部実装アセンブリを参照していません

## 概要
<!-- 変更内容を簡単に記載してください -->
新しい映像エフェクト「光条」を追加します。
映像内の高輝度な点から放射状の光の筋を生やすエフェクトです。カメラのクロスフィルターに相当し、イルミネーション、水面のきらめき、目のハイライト、金属の反射などの点光源の強調に使えます。ゴッドレイが指定した光源位置から画面全体へ放射する面の光であるのに対し、光条は映像内のすべての輝点それぞれから対称な筋を生やす点で役割が異なります。

## エフェクト本体
各画素から指定した本数の方向へ光線を伸ばし、しきい値を超えた輝度を集めて筋として合成します。減衰には絞り羽根による回折スパイクの強度包絡に相当するローレンツ型の重みを使い、根元が明るく先端へ滑らかに消える自然な形になります。分散を上げると、波長に比例して回折距離が伸びる性質に従って赤の重みが遠くまで、青の重みが近くで減衰するため、筋の根元が白く先端へ向かって虹色に色づきます。これは実際のクロスフィルターと同じ色の並びです。

パラメータは強度、しきい値、長さ、本数、角度、太さ、分散、光の色、光のみ表示です。色と表示切替を除く7項目がアニメーションに対応し、角度をアニメーションさせると筋が回転してきらめきの演出になります。本数は1本から16本まで指定できます。光のみ表示を有効にすると筋だけを出力するため、他のレイヤーへ合成する素材としても使えます。出力はパラメータとシーン座標だけから決まる純関数で、時間にも乱数にも依存しないため、フレーム間でちらつきません。

D2Dカスタムエフェクトとしての実装上の要点は次のとおりです。サンプリングは方向ごとに固定24回のギャザーで、反復探索や動的な分岐を含まないため描画コストが安定します。筋は素材の外へ伸びるため、MapInputRectsToOutputRectで出力矩形を長さと太さにバイリニアの近傍参照分を加えたマージンで拡張し、MapOutputRectToInputRectsでも同じマージンで入力矩形を要求して端の欠けを防いでいます。光は入力の輝度から導出されるため、素材の外では自然にゼロになり、拡張した余白に不要な光が出ることはありません。範囲外のサンプリングはUV境界の判定で透明を返します。加算合成後はmin(rgb, a)とアルファの拡張でプリマルチプライドアルファの有効性を保証しています。EffectImplの各プロパティはシェーダーが前提とする値域へクランプし、定数バッファはC#側の構造体と順序、型、16バイト整列を一致させています。
