### PR TITLE
Irodori-TTS VoiceDesignのAPI変更に対応

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community/Voice/IrodoriTTS/IrodoriTTSAPI.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Voice/IrodoriTTS/IrodoriTTSAPI.cs
@@ -10,8 +10,8 @@ namespace YukkuriMovieMaker.Plugin.Community.Voice.IrodoriTTS;
 
 internal static class IrodoriTTSAPI
 {
-    const string DefaultTTSCheckpoint = "Aratako/Irodori-TTS-500M-v2";
-    const string DefaultVoiceDesignCheckpoint = "Aratako/Irodori-TTS-500M-v2-VoiceDesign";
+    const string DefaultTTSCheckpoint = "Aratako/Irodori-TTS-500M-v3";
+    const string DefaultVoiceDesignCheckpoint = "Aratako/Irodori-TTS-600M-v3-VoiceDesign";
     const string DefaultDevice = "cuda";
     const string DefaultPrecision = "fp32";
 
@@ -95,11 +95,13 @@ internal static class IrodoriTTSAPI
         var vdCheckpoint = string.IsNullOrWhiteSpace(checkpoint) ? DefaultVoiceDesignCheckpoint : checkpoint;
 
         // gradio_app_voicedesign.py の _run_generation に対応
-        // 23 params: checkpoint, model_device, model_precision, codec_device, codec_precision,
-        //   enable_watermark (hidden State), text, caption, num_steps, num_candidates,
-        //   seed_raw, cfg_guidance_mode, cfg_scale_text, cfg_scale_caption, cfg_scale_raw,
-        //   cfg_min_t, cfg_max_t, context_kv_cache, max_text_len_raw, max_caption_len_raw,
-        //   truncation_factor_raw, rescale_k_raw, rescale_sigma_raw
+        // 30 params: checkpoint, model_device, model_precision, codec_device, codec_precision,
+        //   text, caption, ref_wav, num_steps, num_candidates, seed_raw,
+        //   seconds_raw, duration_scale, t_schedule_mode, sway_coeff,
+        //   cfg_guidance_mode, cfg_scale_text, cfg_scale_caption, cfg_scale_speaker,
+        //   cfg_scale_raw, cfg_min_t, cfg_max_t, context_kv_cache,
+        //   speaker_kv_scale_raw, max_text_len_raw, max_caption_len_raw,
+        //   truncation_factor_raw, rescale_k_raw, rescale_sigma_raw, lora_adapter_raw
         var data = new JArray
         {
             vdCheckpoint,              // checkpoint
@@ -107,24 +109,31 @@ internal static class IrodoriTTSAPI
             DefaultPrecision,          // model_precision
             DefaultDevice,             // codec_device
             DefaultPrecision,          // codec_precision
-            false,                     // enable_watermark (hidden State component)
             text,                      // text
             caption,                   // caption
+            JValue.CreateNull(),       // ref_wav（VoiceDesignでは参照音声なし）
             numSteps,                  // num_steps
             1,                         // num_candidates
             seed,                      // seed_raw
+            "",                        // seconds_raw（空欄 = 自動）
+            1.0,                       // duration_scale
+            "linear",                  // t_schedule_mode
+            -1.0,                      // sway_coeff
             "independent",             // cfg_guidance_mode
-            2.0,                       // cfg_scale_text (VoiceDesign default)
-            4.0,                       // cfg_scale_caption (VoiceDesign default)
+            3.0,                       // cfg_scale_text
+            4.0,                       // cfg_scale_caption
+            5.0,                       // cfg_scale_speaker
             "",                        // cfg_scale_raw
             0.5,                       // cfg_min_t
             1.0,                       // cfg_max_t
             true,                      // context_kv_cache
+            "",                        // speaker_kv_scale_raw
             "",                        // max_text_len_raw
             "",                        // max_caption_len_raw
             "",                        // truncation_factor_raw
             "",                        // rescale_k_raw
             "",                        // rescale_sigma_raw
+            ""                         // lora_adapter_raw
         };
 
         var result = await CallGradioAsync(baseUrl, "_run_generation", data);

--- a/YukkuriMovieMaker.Plugin.Community/Voice/IrodoriTTS/IrodoriTTSAPI.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Voice/IrodoriTTS/IrodoriTTSAPI.cs
@@ -10,7 +10,7 @@ namespace YukkuriMovieMaker.Plugin.Community.Voice.IrodoriTTS;
 
 internal static class IrodoriTTSAPI
 {
-    const string DefaultTTSCheckpoint = "Aratako/Irodori-TTS-500M-v3";
+    const string DefaultTTSCheckpoint = "Aratako/Irodori-TTS-500M-v2";
     const string DefaultVoiceDesignCheckpoint = "Aratako/Irodori-TTS-600M-v3-VoiceDesign";
     const string DefaultDevice = "cuda";
     const string DefaultPrecision = "fp32";

--- a/YukkuriMovieMaker.Plugin.Community/Voice/IrodoriTTS/IrodoriTTSAPI.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Voice/IrodoriTTS/IrodoriTTSAPI.cs
@@ -1,19 +1,57 @@
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Concurrent;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using YukkuriMovieMaker.Commons;
 
 namespace YukkuriMovieMaker.Plugin.Community.Voice.IrodoriTTS;
 
+/// <summary>
+/// Irodori-TTSサーバー（gradio_app.py / gradio_app_voicedesign.py）の _run_generation API世代。
+/// サーバー側スクリプトの版によって引数の数・並び・参照音声の形が異なるため、呼び出し前に判別して送り分ける。
+/// </summary>
+internal enum IrodoriTTSApiFormat
+{
+    /// <summary>v2タグ（enable_watermark あり。TTS 24引数・VoiceDesign 23引数）</summary>
+    V2,
+    /// <summary>v3タグ（30引数。参照音声は単一の gr.Audio）</summary>
+    V3,
+    /// <summary>v4系＝現行main（30引数。参照音声が gr.File(file_count="multiple") になり配列で送る）</summary>
+    V4,
+}
+
+/// <summary>
+/// /gradio_api/info から判別したサーバーのAPI世代と、サーバーが宣言している既定値
+/// （チェックポイント・デバイス）。デバイスはサーバーの実行環境依存
+/// （CPU版torchでは選択肢が cpu のみになり、cuda を送ると弾かれる）のため、サーバー既定を優先する。
+/// 精度は既定が環境依存（choices の先頭）で、採用すると既存ユーザーの合成結果が変わりうるため fp32 固定を維持する。
+/// </summary>
+internal readonly record struct IrodoriTTSApiInfo(
+    IrodoriTTSApiFormat Format,
+    string? DefaultCheckpoint = null,
+    string? ModelDevice = null,
+    string? CodecDevice = null);
+
 internal static class IrodoriTTSAPI
 {
-    const string DefaultTTSCheckpoint = "Aratako/Irodori-TTS-500M-v2";
-    const string DefaultVoiceDesignCheckpoint = "Aratako/Irodori-TTS-600M-v3-VoiceDesign";
+    const string V2TTSCheckpoint = "Aratako/Irodori-TTS-500M-v2";
+    const string V2VoiceDesignCheckpoint = "Aratako/Irodori-TTS-500M-v2-VoiceDesign";
+    const string V3TTSCheckpoint = "Aratako/Irodori-TTS-500M-v3";
+    const string V3VoiceDesignCheckpoint = "Aratako/Irodori-TTS-600M-v3-VoiceDesign";
+    const string V4Checkpoint = "Aratako/Irodori-TTS-v4-Small";
     const string DefaultDevice = "cuda";
     const string DefaultPrecision = "fp32";
+
+    static readonly TimeSpan detectTimeout = TimeSpan.FromSeconds(10);
+
+    // baseUrl（末尾スラッシュ除去済み）→ 最後に判別できたAPI情報。
+    // 一過性のinfo取得失敗で既存ユーザーの合成を壊さないためのフォールバック用
+    static readonly ConcurrentDictionary<string, IrodoriTTSApiInfo> infoCache = new();
 
     public static async Task<bool> HealthCheckAsync(string baseUrl)
     {
@@ -30,6 +68,168 @@ internal static class IrodoriTTSAPI
         }
     }
 
+    /// <summary>
+    /// /gradio_api/info から _run_generation の引数構成を取得してAPI世代と既定チェックポイントを判別する。
+    /// 一時的な失敗で誤った世代を確定させないよう数回リトライし、それでも失敗した場合は
+    /// 同じサーバーで前回判別できた情報→それも無ければ現行上流（v4）形式の順でフォールバックする
+    /// （infoと合成APIは同一サーバーのため、infoが継続的に取れない状況では合成自体も失敗する見込み）。
+    /// </summary>
+    internal static async Task<IrodoriTTSApiInfo> DetectApiInfoAsync(string baseUrl)
+    {
+        const int maxAttempts = 3;
+        var key = baseUrl.TrimEnd('/');
+        Exception? lastError = null;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            string json;
+            try
+            {
+                var client = HttpClientFactory.Client;
+                using var cts = new CancellationTokenSource(detectTimeout);
+                json = await client.GetStringAsync($"{key}/gradio_api/info", cts.Token);
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+                if (attempt < maxAttempts)
+                    await Task.Delay(TimeSpan.FromMilliseconds(500));
+                continue;
+            }
+
+            try
+            {
+                var info = ParseApiInfo(json);
+                infoCache[key] = info;
+                return info;
+            }
+            catch (Exception ex)
+            {
+                // 応答の解析失敗はリトライしても結果が変わらないため即フォールバックへ
+                lastError = ex;
+                break;
+            }
+        }
+
+        if (infoCache.TryGetValue(key, out var cached))
+        {
+            Log.Default.Write($"Irodori-TTS API format detection failed. Using last known format ({cached.Format}).", lastError!);
+            // 同一URLでTTS/VoiceDesignアプリを切り替える構成（YMM4管理モード）では、
+            // キャッシュ済みの既定チェックポイントが別アプリのものである可能性があるため世代とデバイス系のみ引き継ぐ
+            return cached with { DefaultCheckpoint = null };
+        }
+        Log.Default.Write("Irodori-TTS API format detection failed. Fallback to v4 format.", lastError!);
+        return new(IrodoriTTSApiFormat.V4);
+    }
+
+    internal static IrodoriTTSApiInfo ParseApiInfo(string infoJson)
+    {
+        var info = JObject.Parse(infoJson);
+        if (info["named_endpoints"] is not JObject namedEndpoints
+            || namedEndpoints["/_run_generation"] is not JObject endpoint)
+            throw new InvalidOperationException("_run_generation endpoint not found in Gradio API info.");
+        if (endpoint["parameters"] is not JArray parameters)
+            throw new InvalidOperationException("_run_generation parameters are missing or not an array in Gradio API info.");
+
+        var paramObjects = parameters.OfType<JObject>().ToArray();
+        if (paramObjects.Length == 0)
+            throw new InvalidOperationException("_run_generation has no parameters in Gradio API info.");
+
+        // Gradioはシグネチャを取れないと param_0, param_1, ... を自動命名するため、
+        // 実名（自動命名でない名前）が取れたかどうかで判別方法を切り替える。
+        // 全世代共通で存在する checkpoint が実名に含まれない場合は名前が信頼できないとみなす
+        var names = paramObjects
+            .Select(p => p["parameter_name"]?.ToString() ?? string.Empty)
+            .Where(n => n.Length > 0 && !IsAutoGeneratedParameterName(n))
+            .ToArray();
+
+        var usePosition = !names.Contains("checkpoint");
+        var format = usePosition
+            ? DetectFormatFromParameterShape(paramObjects)
+            : DetectFormatFromParameterNames(names, paramObjects);
+
+        // 空欄時に使う、サーバーが宣言している既定値
+        // （gr.Textbox / gr.Dropdown の value= が /info の parameter_default にそのまま載る。
+        //   チェックポイントはローカル運用も含めWeb UIの既定と一致し、
+        //   デバイス・精度はサーバーの実行環境（CUDAの有無等）に合った値になる）
+        // 引数の並びは全世代共通で checkpoint, model_device, model_precision, codec_device, codec_precision
+        // のため、自動命名で名前が信頼できないときに限り位置から拾う
+        return new(
+            format,
+            DefaultCheckpoint: GetServerDefault(paramObjects, "checkpoint", 0, usePosition),
+            ModelDevice: GetServerDefault(paramObjects, "model_device", 1, usePosition),
+            CodecDevice: GetServerDefault(paramObjects, "codec_device", 3, usePosition));
+    }
+
+    static string? GetServerDefault(JObject[] paramObjects, string parameterName, int position, bool usePosition)
+    {
+        var parameter = paramObjects.FirstOrDefault(p => p["parameter_name"]?.ToString() == parameterName);
+        if (parameter is null && usePosition && position < paramObjects.Length)
+            parameter = paramObjects[position];
+        var token = parameter?["parameter_default"];
+        var value = token?.Type == JTokenType.String ? token.ToString() : null;
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    static bool IsAutoGeneratedParameterName(string name) =>
+        name.Length > "param_".Length
+        && name.StartsWith("param_", StringComparison.Ordinal)
+        && name["param_".Length..].All(char.IsAsciiDigit);
+
+    static IrodoriTTSApiFormat DetectFormatFromParameterNames(string[] names, JObject[] paramObjects)
+    {
+        // seconds_raw はv3タグで追加された引数。無ければv2世代
+        if (!names.Contains("seconds_raw"))
+            return IrodoriTTSApiFormat.V2;
+
+        // VoiceDesignサーバーは参照音声の引数名で判別できる（v3: ref_wav → v4: ref_wavs に改名）
+        if (names.Contains("ref_wavs"))
+            return IrodoriTTSApiFormat.V4;
+        if (names.Contains("ref_wav"))
+            return IrodoriTTSApiFormat.V3;
+
+        // 通常TTSサーバーは引数名が同一なので、uploaded_audio のコンポーネント型で判別する
+        // （v3: gr.Audio＝単一ファイル → v4: gr.File(file_count="multiple")＝配列）
+        var uploadedAudio = paramObjects.FirstOrDefault(p => p["parameter_name"]?.ToString() == "uploaded_audio");
+        if (HasComponent(uploadedAudio, "Audio"))
+            return IrodoriTTSApiFormat.V3;
+        return IrodoriTTSApiFormat.V4;
+    }
+
+    static IrodoriTTSApiFormat DetectFormatFromParameterShape(JObject[] paramObjects)
+    {
+        // 引数の実名が取れないサーバー向けのフォールバック判別。
+        // 引数の個数はv2世代（hidden Stateを除き22〜23個）とv3以降（30個）で明確に分かれる
+        if (paramObjects.Length < 30)
+            return IrodoriTTSApiFormat.V2;
+
+        // v3世代は参照音声にAudioコンポーネントを使う（v4はFileに変更された）
+        return paramObjects.Any(p => HasComponent(p, "Audio"))
+            ? IrodoriTTSApiFormat.V3
+            : IrodoriTTSApiFormat.V4;
+    }
+
+    static bool HasComponent(JObject? parameter, string component) =>
+        string.Equals(parameter?["component"]?.ToString(), component, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// チェックポイント欄が空のときに使うチェックポイントを解決する。
+    /// ユーザー指定 → サーバーが宣言している既定 → 世代別の上流フォールバック値
+    /// （ローカルチェックポイントが無いときに各世代の gradio スクリプトが使う値）の優先順。
+    /// </summary>
+    internal static string ResolveCheckpoint(string checkpoint, IrodoriTTSApiInfo info, bool isVoiceDesign)
+    {
+        if (!string.IsNullOrWhiteSpace(checkpoint))
+            return checkpoint;
+        if (!string.IsNullOrWhiteSpace(info.DefaultCheckpoint))
+            return info.DefaultCheckpoint;
+        return info.Format switch
+        {
+            IrodoriTTSApiFormat.V2 => isVoiceDesign ? V2VoiceDesignCheckpoint : V2TTSCheckpoint,
+            IrodoriTTSApiFormat.V3 => isVoiceDesign ? V3VoiceDesignCheckpoint : V3TTSCheckpoint,
+            _ => V4Checkpoint,
+        };
+    }
+
     public static async Task SynthesizeAsync(
         string baseUrl,
         string text,
@@ -40,30 +240,100 @@ internal static class IrodoriTTSAPI
         string outputPath,
         string checkpoint = "")
     {
+        var info = await DetectApiInfoAsync(baseUrl);
+
         // ref-wav を Gradio にアップロード（セキュリティ制約回避）
         var uploadedPath = await UploadFileAsync(baseUrl, refFilePath);
+        var uploadedAudio = new JObject { ["path"] = uploadedPath, ["meta"] = new JObject { ["_type"] = "gradio.FileData" } };
 
-        var ttsCheckpoint = string.IsNullOrWhiteSpace(checkpoint) ? DefaultTTSCheckpoint : checkpoint;
+        var ttsCheckpoint = ResolveCheckpoint(checkpoint, info, isVoiceDesign: false);
+        var data = CreateSynthesizeData(info, ttsCheckpoint, text, uploadedAudio, numSteps, cfgScaleText, cfgScaleSpeaker);
 
-        // 24 params: checkpoint, model_device, model_precision, codec_device, codec_precision,
-        //   enable_watermark (hidden State), text, uploaded_audio, num_steps, num_candidates,
-        //   seed_raw, cfg_guidance_mode, cfg_scale_text, cfg_scale_speaker, cfg_scale_raw,
-        //   cfg_min_t, cfg_max_t, context_kv_cache, truncation_factor_raw,
-        //   rescale_k_raw, rescale_sigma_raw, speaker_kv_scale_raw,
-        //   speaker_kv_min_t_raw, speaker_kv_max_layers_raw
-        var data = new JArray
+        var result = await CallGradioAsync(baseUrl, "_run_generation", data);
+        await DownloadFirstAudioResult(result, outputPath);
+    }
+
+    internal static JArray CreateSynthesizeData(
+        IrodoriTTSApiInfo info,
+        string checkpoint,
+        string text,
+        JToken uploadedAudio,
+        int numSteps,
+        double cfgScaleText,
+        double cfgScaleSpeaker)
+    {
+        // デバイスはサーバーが宣言する既定を優先する（CPU版torchのサーバーに cuda を送ると弾かれる）
+        var modelDevice = info.ModelDevice ?? DefaultDevice;
+        var codecDevice = info.CodecDevice ?? DefaultDevice;
+
+        if (info.Format is IrodoriTTSApiFormat.V2)
         {
-            ttsCheckpoint,             // checkpoint
-            DefaultDevice,             // model_device
+            // v2タグの gradio_app.py の _run_generation に対応
+            // 24 params: checkpoint, model_device, model_precision, codec_device, codec_precision,
+            //   enable_watermark (hidden State), text, uploaded_audio, num_steps, num_candidates,
+            //   seed_raw, cfg_guidance_mode, cfg_scale_text, cfg_scale_speaker, cfg_scale_raw,
+            //   cfg_min_t, cfg_max_t, context_kv_cache, truncation_factor_raw,
+            //   rescale_k_raw, rescale_sigma_raw, speaker_kv_scale_raw,
+            //   speaker_kv_min_t_raw, speaker_kv_max_layers_raw
+            return
+            [
+                checkpoint,                // checkpoint
+                modelDevice,               // model_device
+                DefaultPrecision,          // model_precision
+                codecDevice,               // codec_device
+                DefaultPrecision,          // codec_precision
+                false,                     // enable_watermark (hidden State component)
+                text,                      // text
+                uploadedAudio,             // uploaded_audio (ref-wav)
+                numSteps,                  // num_steps
+                1,                         // num_candidates
+                "",                        // seed_raw (empty = random)
+                "independent",             // cfg_guidance_mode
+                cfgScaleText,              // cfg_scale_text
+                cfgScaleSpeaker,           // cfg_scale_speaker
+                "",                        // cfg_scale_raw
+                0.5,                       // cfg_min_t
+                1.0,                       // cfg_max_t
+                true,                      // context_kv_cache
+                "",                        // truncation_factor_raw
+                "",                        // rescale_k_raw
+                "",                        // rescale_sigma_raw
+                "",                        // speaker_kv_scale_raw
+                "",                        // speaker_kv_min_t_raw
+                "",                        // speaker_kv_max_layers_raw
+            ];
+        }
+
+        // v3タグ以降の gradio_app.py の _run_generation に対応
+        // 30 params: checkpoint, model_device, model_precision, codec_device, codec_precision,
+        //   text, uploaded_audio, uploaded_speaker_embedding, speaker_embedding_path_raw,
+        //   num_steps, num_candidates, seed_raw, seconds_raw, duration_scale, t_schedule_mode,
+        //   sway_coeff, cfg_guidance_mode, cfg_scale_text, cfg_scale_speaker, cfg_scale_raw,
+        //   cfg_min_t, cfg_max_t, context_kv_cache, truncation_factor_raw, rescale_k_raw,
+        //   rescale_sigma_raw, speaker_kv_scale_raw, speaker_kv_min_t_raw,
+        //   speaker_kv_max_layers_raw, lora_adapter_raw
+        // v4は uploaded_audio が gr.File(file_count="multiple") のため FileData の配列で送る
+        var refAudio = info.Format is IrodoriTTSApiFormat.V4
+            ? new JArray(uploadedAudio)
+            : uploadedAudio;
+        return
+        [
+            checkpoint,                // checkpoint
+            modelDevice,               // model_device
             DefaultPrecision,          // model_precision
-            DefaultDevice,             // codec_device
+            codecDevice,               // codec_device
             DefaultPrecision,          // codec_precision
-            false,                     // enable_watermark (hidden State component)
             text,                      // text
-            new JObject { ["path"] = uploadedPath, ["meta"] = new JObject { ["_type"] = "gradio.FileData" } },  // uploaded_audio (ref-wav)
+            refAudio,                  // uploaded_audio (ref-wav)
+            JValue.CreateNull(),       // uploaded_speaker_embedding
+            "",                        // speaker_embedding_path_raw
             numSteps,                  // num_steps
             1,                         // num_candidates
             "",                        // seed_raw (empty = random)
+            "",                        // seconds_raw（空欄 = 自動）
+            1.0,                       // duration_scale
+            "linear",                  // t_schedule_mode
+            -1.0,                      // sway_coeff
             "independent",             // cfg_guidance_mode
             cfgScaleText,              // cfg_scale_text
             cfgScaleSpeaker,           // cfg_scale_speaker
@@ -75,12 +345,10 @@ internal static class IrodoriTTSAPI
             "",                        // rescale_k_raw
             "",                        // rescale_sigma_raw
             "",                        // speaker_kv_scale_raw
-            "",                        // speaker_kv_min_t_raw
+            "",                        // speaker_kv_min_t_raw（空欄 = サーバー側既定。v2形式と挙動を揃える）
             "",                        // speaker_kv_max_layers_raw
-        };
-
-        var result = await CallGradioAsync(baseUrl, "_run_generation", data);
-        await DownloadFirstAudioResult(result, outputPath);
+            "",                        // lora_adapter_raw
+        ];
     }
 
     public static async Task VoiceDesignAsync(
@@ -92,26 +360,82 @@ internal static class IrodoriTTSAPI
         string outputPath,
         string checkpoint = "")
     {
-        var vdCheckpoint = string.IsNullOrWhiteSpace(checkpoint) ? DefaultVoiceDesignCheckpoint : checkpoint;
+        var info = await DetectApiInfoAsync(baseUrl);
 
-        // gradio_app_voicedesign.py の _run_generation に対応
+        var vdCheckpoint = ResolveCheckpoint(checkpoint, info, isVoiceDesign: true);
+        var data = CreateVoiceDesignData(info, vdCheckpoint, text, caption, seed, numSteps);
+
+        var result = await CallGradioAsync(baseUrl, "_run_generation", data);
+        await DownloadFirstAudioResult(result, outputPath);
+    }
+
+    internal static JArray CreateVoiceDesignData(
+        IrodoriTTSApiInfo info,
+        string checkpoint,
+        string text,
+        string caption,
+        string seed,
+        int numSteps)
+    {
+        // デバイスはサーバーが宣言する既定を優先する（CPU版torchのサーバーに cuda を送ると弾かれる）
+        var modelDevice = info.ModelDevice ?? DefaultDevice;
+        var codecDevice = info.CodecDevice ?? DefaultDevice;
+
+        if (info.Format is IrodoriTTSApiFormat.V2)
+        {
+            // v2タグの gradio_app_voicedesign.py の _run_generation に対応
+            // 23 params: checkpoint, model_device, model_precision, codec_device, codec_precision,
+            //   enable_watermark (hidden State), text, caption, num_steps, num_candidates,
+            //   seed_raw, cfg_guidance_mode, cfg_scale_text, cfg_scale_caption, cfg_scale_raw,
+            //   cfg_min_t, cfg_max_t, context_kv_cache, max_text_len_raw, max_caption_len_raw,
+            //   truncation_factor_raw, rescale_k_raw, rescale_sigma_raw
+            return
+            [
+                checkpoint,                // checkpoint
+                modelDevice,               // model_device
+                DefaultPrecision,          // model_precision
+                codecDevice,               // codec_device
+                DefaultPrecision,          // codec_precision
+                false,                     // enable_watermark (hidden State component)
+                text,                      // text
+                caption,                   // caption
+                numSteps,                  // num_steps
+                1,                         // num_candidates
+                seed,                      // seed_raw
+                "independent",             // cfg_guidance_mode
+                2.0,                       // cfg_scale_text (VoiceDesign default)
+                4.0,                       // cfg_scale_caption (VoiceDesign default)
+                "",                        // cfg_scale_raw
+                0.5,                       // cfg_min_t
+                1.0,                       // cfg_max_t
+                true,                      // context_kv_cache
+                "",                        // max_text_len_raw
+                "",                        // max_caption_len_raw
+                "",                        // truncation_factor_raw
+                "",                        // rescale_k_raw
+                "",                        // rescale_sigma_raw
+            ];
+        }
+
+        // v3タグ以降の gradio_app_voicedesign.py の _run_generation に対応
         // 30 params: checkpoint, model_device, model_precision, codec_device, codec_precision,
-        //   text, caption, ref_wav, num_steps, num_candidates, seed_raw,
+        //   text, caption, ref_wav(v4では ref_wavs), num_steps, num_candidates, seed_raw,
         //   seconds_raw, duration_scale, t_schedule_mode, sway_coeff,
         //   cfg_guidance_mode, cfg_scale_text, cfg_scale_caption, cfg_scale_speaker,
         //   cfg_scale_raw, cfg_min_t, cfg_max_t, context_kv_cache,
         //   speaker_kv_scale_raw, max_text_len_raw, max_caption_len_raw,
         //   truncation_factor_raw, rescale_k_raw, rescale_sigma_raw, lora_adapter_raw
-        var data = new JArray
-        {
-            vdCheckpoint,              // checkpoint
-            DefaultDevice,             // model_device
+        // 参照音声はVoiceDesignでは使わないため、v3（単一）/v4（複数）とも null でよい
+        return
+        [
+            checkpoint,                // checkpoint
+            modelDevice,               // model_device
             DefaultPrecision,          // model_precision
-            DefaultDevice,             // codec_device
+            codecDevice,               // codec_device
             DefaultPrecision,          // codec_precision
             text,                      // text
             caption,                   // caption
-            JValue.CreateNull(),       // ref_wav（VoiceDesignでは参照音声なし）
+            JValue.CreateNull(),       // ref_wav / ref_wavs（VoiceDesignでは参照音声なし）
             numSteps,                  // num_steps
             1,                         // num_candidates
             seed,                      // seed_raw
@@ -133,11 +457,8 @@ internal static class IrodoriTTSAPI
             "",                        // truncation_factor_raw
             "",                        // rescale_k_raw
             "",                        // rescale_sigma_raw
-            ""                         // lora_adapter_raw
-        };
-
-        var result = await CallGradioAsync(baseUrl, "_run_generation", data);
-        await DownloadFirstAudioResult(result, outputPath);
+            "",                        // lora_adapter_raw
+        ];
     }
 
     static async Task<JArray> CallGradioAsync(string baseUrl, string apiName, JArray data)


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [x] このPRには1つの機能（または1つの修正）のみが含まれています
- [x] `YukkuriMovieMaker.dll`などYMM4本体の内部実装アセンブリを参照していません

## 概要

Irodori-TTSのVoiceDesignで`Gradio error: null`が発生し、音声生成できない問題を修正しました。

### 原因

`gradio_app_voicedesign.py`の`_run_generation` APIが更新され、引数が23個から30個へ変更されていました。
そのため、YMM4側が旧仕様の引数を送信し、VoiceDesignから音声生成ができなくなっていました。

### 修正内容

- VoiceDesign APIの仕様変更に合わせて`_run_generation`呼び出しを30引数に対応
- VoiceDesignの既定チェックポイントを`Aratako/Irodori-TTS-600M-v3-VoiceDesign`へ更新

### 動作確認

- YMM4 v4.55.0.1
- Aratako/Irodori-TTS-600M-v3-VoiceDesign
- VoiceDesignから正常に音声生成ができることを確認
