### PR TITLE
波形「メタボール」を追加

### DIFF
--- a/YukkuriMovieMaker.Plugin.Community.Shader/MetaballSpectrum.hlsl
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/MetaballSpectrum.hlsl
@@ -1,0 +1,72 @@
+cbuffer Constants : register(b0)
+{
+    float4 field : packoffset(c0);
+    float4 style : packoffset(c1);
+    float4 options : packoffset(c2);
+    float4 tint : packoffset(c3);
+    float4 values[64] : packoffset(c4);
+};
+
+float SpectrumLane(float4 packed, int lane)
+{
+    float2 pair = lane < 2 ? packed.xy : packed.zw;
+    return (lane & 1) == 0 ? pair.x : pair.y;
+}
+
+float4 main(
+    float4 position : SV_POSITION,
+    float4 scenePosition : SCENE_POSITION,
+    float4 uv0 : TEXCOORD0
+) : SV_TARGET
+{
+    int count = (int)field.z;
+    if (count < 1)
+        return float4(0.0, 0.0, 0.0, 0.0);
+
+    float width = field.x;
+    float height = field.y;
+    float radius = field.w;
+    float threshold = style.x;
+    int window = (int)style.y;
+    float bipolar = options.x;
+
+    float halfWidth = width * 0.5;
+    float halfHeight = height * 0.5;
+    float columnWidth = width / count;
+    float baseline = bipolar > 0.5 ? 0.0 : halfHeight;
+    float span = bipolar > 0.5 ? halfHeight : height;
+
+    float2 local = scenePosition.xy;
+    float antialias = max(max(fwidth(local.x), fwidth(local.y)), 0.5);
+
+    int nearest = (int)floor((local.x + halfWidth) / columnWidth);
+    float density = 0.0;
+    float2 gradient = float2(0.0, 0.0);
+
+    [loop]
+    for (int offset = -window; offset <= window; offset++)
+    {
+        int index = nearest + offset;
+        if (index < 0 || index >= count)
+            continue;
+
+        float value = SpectrumLane(values[index >> 2], index & 3);
+        float reach = (bipolar > 0.5 ? value : abs(value)) * span;
+        float centreX = -halfWidth + (index + 0.5) * columnWidth;
+
+        float slide = abs(reach) > 0.0001 ? saturate((local.y - baseline) / -reach) : 0.0;
+        float2 delta = local - float2(centreX, baseline - slide * reach);
+        float ratio = length(delta) / radius;
+        if (ratio >= 1.0)
+            continue;
+
+        float shell = 1.0 - ratio * ratio;
+        density += shell * shell * shell;
+        gradient += delta * (-6.0 * shell * shell / (radius * radius));
+    }
+
+    float slope = max(length(gradient), 0.00001);
+    float signedDistance = (density - threshold) / slope;
+    float coverage = saturate(signedDistance / antialias + 0.5) * tint.a;
+    return float4(tint.rgb * coverage, coverage);
+}

--- a/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj
@@ -600,6 +600,12 @@
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
     </FxCompile>
+	<FxCompile Include="MetaballSpectrum.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+    </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Hash.hlsli" />

--- a/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj.filters
+++ b/YukkuriMovieMaker.Plugin.Community.Shader/YukkuriMovieMaker.Plugin.Community.Shader.vcxproj.filters
@@ -237,6 +237,9 @@
     <FxCompile Include="RadianceOccupancy.hlsl">
       <Filter>ソース ファイル</Filter>
     </FxCompile>
+    <FxCompile Include="MetaballSpectrum.hlsl">
+      <Filter>ソース ファイル</Filter>
+    </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Hash.hlsli">

--- a/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/MetaballSpectrumCustomEffect.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/MetaballSpectrumCustomEffect.cs
@@ -1,0 +1,138 @@
+using System.Runtime.InteropServices;
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Community.Commons;
+
+namespace YukkuriMovieMaker.Plugin.Community.Shape.MetaballSpectrum
+{
+    internal sealed class MetaballSpectrumCustomEffect(IGraphicsDevicesAndContext devices) : D2D1CustomShaderEffectBase(Create<EffectImpl>(devices))
+    {
+        public const int MaxValues = 256;
+        public const int MaxWindow = 64;
+        public const int ValueByteSize = MaxValues * sizeof(float);
+
+        private enum PropertyIndex
+        {
+            FieldWidth = 0,
+            FieldHeight,
+            ValueCount,
+            BlobRadius,
+            Threshold,
+            Window,
+            Bipolar,
+            ColorR,
+            ColorG,
+            ColorB,
+            ColorA,
+            Values,
+        }
+
+        public float FieldWidth { set => SetValue((int)PropertyIndex.FieldWidth, value); }
+        public float FieldHeight { set => SetValue((int)PropertyIndex.FieldHeight, value); }
+        public float ValueCount { set => SetValue((int)PropertyIndex.ValueCount, value); }
+        public float BlobRadius { set => SetValue((int)PropertyIndex.BlobRadius, value); }
+        public float Threshold { set => SetValue((int)PropertyIndex.Threshold, value); }
+        public float Window { set => SetValue((int)PropertyIndex.Window, value); }
+        public float Bipolar { set => SetValue((int)PropertyIndex.Bipolar, value); }
+        public float ColorR { set => SetValue((int)PropertyIndex.ColorR, value); }
+        public float ColorG { set => SetValue((int)PropertyIndex.ColorG, value); }
+        public float ColorB { set => SetValue((int)PropertyIndex.ColorB, value); }
+        public float ColorA { set => SetValue((int)PropertyIndex.ColorA, value); }
+        public byte[] Values { set => SetValue((int)PropertyIndex.Values, value); }
+
+        [CustomEffect(1)]
+        private sealed class EffectImpl : D2D1CustomShaderEffectImplBase<EffectImpl>
+        {
+            private const int HeaderByteSize = 64;
+            private const int ConstantBufferByteSize = HeaderByteSize + ValueByteSize;
+
+            private ConstantBuffer _cb;
+            private readonly byte[] _values = new byte[ValueByteSize];
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.FieldWidth)]
+            public float FieldWidth { get => _cb.FieldWidth; set { _cb.FieldWidth = Math.Max(value, 0.001f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.FieldHeight)]
+            public float FieldHeight { get => _cb.FieldHeight; set { _cb.FieldHeight = Math.Max(value, 0.001f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.ValueCount)]
+            public float ValueCount { get => _cb.ValueCount; set { _cb.ValueCount = Math.Clamp(value, 0f, MaxValues); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.BlobRadius)]
+            public float BlobRadius { get => _cb.BlobRadius; set { _cb.BlobRadius = Math.Max(value, 0.001f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Threshold)]
+            public float Threshold { get => _cb.Threshold; set { _cb.Threshold = Math.Clamp(value, 0.001f, 0.999f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Window)]
+            public float Window { get => _cb.Window; set { _cb.Window = Math.Clamp(value, 0f, MaxWindow); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.Bipolar)]
+            public float Bipolar { get => _cb.Bipolar; set { _cb.Bipolar = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.ColorR)]
+            public float ColorR { get => _cb.ColorR; set { _cb.ColorR = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.ColorG)]
+            public float ColorG { get => _cb.ColorG; set { _cb.ColorG = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.ColorB)]
+            public float ColorB { get => _cb.ColorB; set { _cb.ColorB = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Float, (int)PropertyIndex.ColorA)]
+            public float ColorA { get => _cb.ColorA; set { _cb.ColorA = Math.Clamp(value, 0f, 1f); UpdateConstants(); } }
+
+            [CustomEffectProperty(PropertyType.Blob, (int)PropertyIndex.Values)]
+            public byte[] Values
+            {
+                get => _values;
+                set
+                {
+                    if (value is null)
+                        return;
+                    var length = Math.Min(value.Length, _values.Length);
+                    Array.Copy(value, _values, length);
+                    Array.Clear(_values, length, _values.Length - length);
+                    UpdateConstants();
+                }
+            }
+
+            public EffectImpl() : base(ShaderResourceUri.Get("MetaballSpectrum"))
+            {
+            }
+
+            protected override void UpdateConstants()
+            {
+                if (drawInformation is null)
+                    return;
+
+                Span<byte> buffer = stackalloc byte[ConstantBufferByteSize];
+                MemoryMarshal.Write(buffer, in _cb);
+                _values.CopyTo(buffer[HeaderByteSize..]);
+                drawInformation.SetPixelShaderConstantBuffer(buffer);
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            private struct ConstantBuffer
+            {
+                public float FieldWidth;
+                public float FieldHeight;
+                public float ValueCount;
+                public float BlobRadius;
+                public float Threshold;
+                public float Window;
+                public float Pad0;
+                public float Pad1;
+                public float Bipolar;
+                public float Pad2;
+                public float Pad3;
+                public float Pad4;
+                public float ColorR;
+                public float ColorG;
+                public float ColorB;
+                public float ColorA;
+            }
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/MetaballSpectrumParameter.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/MetaballSpectrumParameter.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel.DataAnnotations;
+using System.Windows.Media;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Controls;
+using YukkuriMovieMaker.Exo;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Shape;
+using YukkuriMovieMaker.Project;
+
+namespace YukkuriMovieMaker.Plugin.Community.Shape.MetaballSpectrum
+{
+    public class MetaballSpectrumParameter(SharedDataStore? sharedData = null) : AudioSpectrumParameterBase(sharedData)
+    {
+        [Display(Name = nameof(Texts.FieldWidth), Description = nameof(Texts.FieldWidthDescription), Order = 10, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", 0, 1920)]
+        public Animation FieldWidth { get; } = new Animation(600, 0.01, YMM4Constants.VeryLargeValue);
+
+        [Display(Name = nameof(Texts.FieldHeight), Description = nameof(Texts.FieldHeightDescription), Order = 11, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", 0, 1080)]
+        public Animation FieldHeight { get; } = new Animation(300, 0.01, YMM4Constants.VeryLargeValue);
+
+        [Display(Name = nameof(Texts.BlobRadius), Description = nameof(Texts.BlobRadiusDescription), Order = 12, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "px", 1, 120)]
+        public Animation BlobRadius { get; } = new Animation(36, 0.01, YMM4Constants.VeryLargeValue);
+
+        [Display(Name = nameof(Texts.Threshold), Description = nameof(Texts.ThresholdDescription), Order = 13, ResourceType = typeof(Texts))]
+        [AnimationSlider("F1", "%", 5, 95)]
+        public Animation Threshold { get; } = new Animation(45, 0.1, 99.9);
+
+        [Display(Name = nameof(Texts.IsBipolar), Description = nameof(Texts.IsBipolarDescription), Order = 14, ResourceType = typeof(Texts))]
+        [ToggleSlider]
+        public bool IsBipolar { get => isBipolar; set => Set(ref isBipolar, value); }
+        private bool isBipolar = false;
+
+        [Display(Name = nameof(Texts.MetaballColor), Description = nameof(Texts.MetaballColorDescription), Order = 15, ResourceType = typeof(Texts))]
+        [ColorPicker]
+        public Color MetaballColor { get => metaballColor; set => Set(ref metaballColor, value); }
+        private Color metaballColor = Colors.White;
+
+        public override IEnumerable<string> CreateShapeItemExoFilter(int keyFrameIndex, ExoOutputDescription desc, AudioSpectrumExoOutputDescription spectrumParameters) => [];
+
+        public override IEnumerable<string> CreateMaskExoFilter(int keyFrameIndex, ExoOutputDescription desc, ShapeMaskExoOutputDescription shapeMaskParameters, AudioSpectrumExoOutputDescription spectrumParameters) => [];
+
+        public override IAudioSpectrumSource CreateShapeSource(IGraphicsDevicesAndContext devices)
+        {
+            return new MetaballSpectrumSource(devices, this);
+        }
+
+        protected override IEnumerable<IAnimatable> GetAnimatables() =>
+            [FieldWidth, FieldHeight, BlobRadius, Threshold];
+
+        protected override void LoadSharedData(SharedDataStore sharedData)
+        {
+            var data = sharedData.Load<MetaballSpectrumParameterData>();
+            if (data is null)
+                return;
+
+            FieldWidth.CopyFrom(data.FieldWidth);
+            FieldHeight.CopyFrom(data.FieldHeight);
+            BlobRadius.CopyFrom(data.BlobRadius);
+            Threshold.CopyFrom(data.Threshold);
+            IsBipolar = data.IsBipolar;
+            MetaballColor = data.MetaballColor;
+        }
+
+        protected override void SaveSharedData(SharedDataStore store)
+        {
+            store.Save(new MetaballSpectrumParameterData(this));
+        }
+    }
+
+    public class MetaballSpectrumParameterData
+    {
+        public Animation FieldWidth { get; } = new Animation(600, 0.01, YMM4Constants.VeryLargeValue);
+        public Animation FieldHeight { get; } = new Animation(300, 0.01, YMM4Constants.VeryLargeValue);
+        public Animation BlobRadius { get; } = new Animation(36, 0.01, YMM4Constants.VeryLargeValue);
+        public Animation Threshold { get; } = new Animation(45, 0.1, 99.9);
+        public bool IsBipolar { get; set; }
+        public Color MetaballColor { get; set; }
+
+        public MetaballSpectrumParameterData(MetaballSpectrumParameter target)
+        {
+            FieldWidth.CopyFrom(target.FieldWidth);
+            FieldHeight.CopyFrom(target.FieldHeight);
+            BlobRadius.CopyFrom(target.BlobRadius);
+            Threshold.CopyFrom(target.Threshold);
+            IsBipolar = target.IsBipolar;
+            MetaballColor = target.MetaballColor;
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/MetaballSpectrumPlugin.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/MetaballSpectrumPlugin.cs
@@ -1,0 +1,19 @@
+using YukkuriMovieMaker.Plugin.Shape;
+using YukkuriMovieMaker.Project;
+
+namespace YukkuriMovieMaker.Plugin.Community.Shape.MetaballSpectrum
+{
+    internal class MetaballSpectrumPlugin : IAudioSpectrumPlugin
+    {
+        public string Name => Texts.MetaballSpectrum;
+
+        public bool IsExoShapeSupported => false;
+
+        public bool IsExoMaskSupported => false;
+
+        public IAudioSpectrumParameter CreateAudioSpectrumParameter(SharedDataStore? sharedData)
+        {
+            return new MetaballSpectrumParameter(sharedData);
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/MetaballSpectrumSource.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/MetaballSpectrumSource.cs
@@ -1,0 +1,154 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+using Vortice.Direct2D1;
+using YukkuriMovieMaker.Commons;
+using YukkuriMovieMaker.Player.Video;
+using YukkuriMovieMaker.Plugin.Shape;
+using D2DEffects = Vortice.Direct2D1.Effects;
+
+namespace YukkuriMovieMaker.Plugin.Community.Shape.MetaballSpectrum
+{
+    internal sealed class MetaballSpectrumSource : IAudioSpectrumSource
+    {
+        private const int WindowLimit = MetaballSpectrumCustomEffect.MaxWindow;
+
+        private readonly DisposeCollector _disposer = new();
+        private readonly MetaballSpectrumParameter _parameter;
+        private readonly byte[] _valueBytes = new byte[MetaballSpectrumCustomEffect.ValueByteSize];
+
+        private readonly D2DEffects.Flood _flood;
+        private readonly D2DEffects.Crop _crop;
+        private MetaballSpectrumCustomEffect? _effect;
+
+        private bool _isFirst = true;
+        private Vector4 _cropRect;
+        private Parameters _parameters;
+
+        public ID2D1Image Output { get; }
+
+        public MetaballSpectrumSource(IGraphicsDevicesAndContext devices, MetaballSpectrumParameter parameter)
+        {
+            _parameter = parameter;
+
+            _flood = new D2DEffects.Flood(devices.DeviceContext);
+            _disposer.Collect(_flood);
+            _crop = new D2DEffects.Crop(devices.DeviceContext);
+            _disposer.Collect(_crop);
+            _flood.Color = new Vector4(0f, 0f, 0f, 0f);
+
+            _effect = new MetaballSpectrumCustomEffect(devices);
+            _disposer.Collect(_effect);
+
+            if (!_effect.IsEnabled)
+            {
+                _disposer.RemoveAndDispose(ref _effect);
+                _crop.Rectangle = new Vector4(0f, 0f, 0f, 0f);
+                using (var output = _flood.Output)
+                    _crop.SetInput(0, output, true);
+            }
+            else
+            {
+                using (var output = _flood.Output)
+                    _effect.SetInput(0, output, true);
+                using (var output = _effect.Output)
+                    _crop.SetInput(0, output, true);
+            }
+
+            var result = _crop.Output;
+            _disposer.Collect(result);
+            Output = result;
+        }
+
+        public void Update(TimelineItemSourceDescription desc, float[] spectrum)
+        {
+            if (_effect is null)
+                return;
+
+            var frame = desc.ItemPosition.Frame;
+            var length = desc.ItemDuration.Frame;
+            var fps = desc.FPS;
+            var color = _parameter.MetaballColor;
+
+            var count = SpectrumResampler.Resample(spectrum, MemoryMarshal.Cast<byte, float>(_valueBytes.AsSpan()));
+
+            var fieldWidth = _parameter.FieldWidth.GetValue(frame, length, fps);
+            var radius = _parameter.BlobRadius.GetValue(frame, length, fps);
+
+            var window = 0;
+            if (count > 0)
+            {
+                var columnWidth = fieldWidth / count;
+                radius = Math.Min(radius, (WindowLimit - 0.5) * columnWidth);
+                window = Math.Clamp((int)Math.Ceiling(0.5 + radius / columnWidth), 1, WindowLimit);
+            }
+
+            var parameters = new Parameters(
+                (float)fieldWidth,
+                (float)_parameter.FieldHeight.GetValue(frame, length, fps),
+                (float)radius,
+                (float)(_parameter.Threshold.GetValue(frame, length, fps) / 100.0),
+                window,
+                _parameter.IsBipolar ? 1f : 0f,
+                color.R / 255f,
+                color.G / 255f,
+                color.B / 255f,
+                color.A / 255f);
+
+            if (_isFirst || _parameters.FieldWidth != parameters.FieldWidth)
+                _effect.FieldWidth = parameters.FieldWidth;
+            if (_isFirst || _parameters.FieldHeight != parameters.FieldHeight)
+                _effect.FieldHeight = parameters.FieldHeight;
+            if (_isFirst || _parameters.BlobRadius != parameters.BlobRadius)
+                _effect.BlobRadius = parameters.BlobRadius;
+            if (_isFirst || _parameters.Threshold != parameters.Threshold)
+                _effect.Threshold = parameters.Threshold;
+            if (_isFirst || _parameters.Window != parameters.Window)
+                _effect.Window = parameters.Window;
+            if (_isFirst || _parameters.Bipolar != parameters.Bipolar)
+                _effect.Bipolar = parameters.Bipolar;
+            if (_isFirst || _parameters.ColorR != parameters.ColorR)
+                _effect.ColorR = parameters.ColorR;
+            if (_isFirst || _parameters.ColorG != parameters.ColorG)
+                _effect.ColorG = parameters.ColorG;
+            if (_isFirst || _parameters.ColorB != parameters.ColorB)
+                _effect.ColorB = parameters.ColorB;
+            if (_isFirst || _parameters.ColorA != parameters.ColorA)
+                _effect.ColorA = parameters.ColorA;
+
+            _effect.ValueCount = count;
+            _effect.Values = _valueBytes;
+
+            var margin = parameters.BlobRadius + 2f;
+            var halfWidth = parameters.FieldWidth * 0.5f + margin;
+            var halfHeight = parameters.FieldHeight * 0.5f + margin;
+            var cropRect = new Vector4(-halfWidth, -halfHeight, halfWidth, halfHeight);
+            if (_isFirst || _cropRect != cropRect)
+            {
+                _crop.Rectangle = cropRect;
+                _cropRect = cropRect;
+            }
+
+            _parameters = parameters;
+            _isFirst = false;
+        }
+
+        public void Dispose()
+        {
+            _crop.SetInput(0, null, true);
+            _effect?.SetInput(0, null, true);
+            _disposer.DisposeAndClear();
+        }
+
+        private readonly record struct Parameters(
+            float FieldWidth,
+            float FieldHeight,
+            float BlobRadius,
+            float Threshold,
+            float Window,
+            float Bipolar,
+            float ColorR,
+            float ColorG,
+            float ColorB,
+            float ColorA);
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/SpectrumResampler.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/SpectrumResampler.cs
@@ -1,0 +1,45 @@
+namespace YukkuriMovieMaker.Plugin.Community.Shape.MetaballSpectrum
+{
+    internal static class SpectrumResampler
+    {
+        public static int Resample(float[]? source, Span<float> destination)
+        {
+            var length = source?.Length ?? 0;
+            if (length <= 0 || destination.Length <= 0)
+            {
+                destination.Clear();
+                return 0;
+            }
+
+            var count = Math.Min(length, destination.Length);
+            for (var i = 0; i < count; i++)
+            {
+                var begin = (int)((long)i * length / count);
+                var end = (int)((long)(i + 1) * length / count);
+                if (end <= begin)
+                    end = begin + 1;
+
+                var extremum = 0f;
+                var magnitude = 0f;
+                for (var j = begin; j < end && j < length; j++)
+                {
+                    var value = source![j];
+                    if (!float.IsFinite(value))
+                        continue;
+
+                    var scale = Math.Abs(value);
+                    if (scale > magnitude)
+                    {
+                        magnitude = scale;
+                        extremum = value;
+                    }
+                }
+
+                destination[i] = Math.Clamp(extremum, -1f, 1f);
+            }
+
+            destination[count..].Clear();
+            return count;
+        }
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/Texts.cs
+++ b/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/Texts.cs
@@ -1,0 +1,10 @@
+using YukkuriMovieMaker.Generator;
+
+namespace YukkuriMovieMaker.Plugin.Community.Shape.MetaballSpectrum
+{
+    [AutoGenLocalizer]
+    partial class Texts
+    {
+
+    }
+}

--- a/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/Texts.csv
+++ b/YukkuriMovieMaker.Plugin.Community/Shape/MetaballSpectrum/Texts.csv
@@ -1,0 +1,14 @@
+Key,Parameter,ja-jp,en-us,zh-cn,zh-tw,ko-kr,es-es,ar-sa,id-id
+MetaballSpectrum,,メタボール,Metaballs,融合球,融合球,메타볼,Metabolas,كرات ميتا,Metaball
+FieldWidth,,幅,Width,宽度,寬度,너비,Anchura,العرض,Lebar
+FieldWidthDescription,,塊が並ぶ範囲の横幅です,Width of the area the blobs occupy.,融合球分布区域的宽度。,融合球分佈區域的寬度。,덩어리가 놓이는 영역의 너비입니다.,Anchura del área que ocupan las metabolas.,عرض المنطقة التي تشغلها الكرات.,Lebar area yang ditempati gumpalan.
+FieldHeight,,高さ,Height,高度,高度,높이,Altura,الارتفاع,Tinggi
+FieldHeightDescription,,値が最大のときに塊が伸びる高さです,Height a blob reaches at the maximum value.,数值最大时融合球伸展的高度。,數值最大時融合球伸展的高度。,값이 최대일 때 덩어리가 뻗는 높이입니다.,Altura que alcanza una metabola con el valor máximo.,الارتفاع الذي تصل إليه الكرة عند القيمة القصوى.,Tinggi yang dicapai gumpalan pada nilai maksimum.
+BlobRadius,,塊の半径,Blob Radius,球半径,球半徑,덩어리 반지름,Radio de metabola,نصف قطر الكرة,Radius Gumpalan
+BlobRadiusDescription,,塊が影響を及ぼす範囲です。大きくすると隣と融合しやすくなります。列の幅に対して上限があります,Range a blob influences. Larger values make neighbours merge more readily. It is capped relative to the column width.,融合球的影响范围。数值越大越容易与相邻的融合。上限取决于列宽。,融合球的影響範圍。數值越大越容易與相鄰的融合。上限取決於列寬。,덩어리가 영향을 미치는 범위입니다. 크게 하면 옆과 잘 융합됩니다. 열 너비에 대한 상한이 있습니다.,Rango de influencia de una metabola. Valores mayores facilitan la fusión con las vecinas. Está limitado en relación con el ancho de columna.,نطاق تأثير الكرة. القيم الأكبر تجعل الاندماج مع المجاورات أسهل. وهو محدود نسبة إلى عرض العمود.,Rentang pengaruh gumpalan. Nilai lebih besar mempermudah penyatuan dengan tetangga. Dibatasi relatif terhadap lebar kolom.
+Threshold,,融合のしきい値,Merge Threshold,融合阈值,融合閾值,융합 임계값,Umbral de fusión,عتبة الاندماج,Ambang Penyatuan
+ThresholdDescription,,表面と見なす密度です。低くすると塊が太り、高くすると細ります,"Density treated as the surface. Lower values fatten the blobs, higher values thin them.",视为表面的密度。数值越低融合球越粗，越高越细。,視為表面的密度。數值越低融合球越粗，越高越細。,표면으로 보는 밀도입니다. 낮추면 덩어리가 굵어지고 높이면 얇아집니다.,Densidad considerada como superficie. Valores bajos engrosan las metabolas y valores altos las adelgazan.,الكثافة التي تُعد سطحا. القيم المنخفضة تسمّن الكرات والمرتفعة ترققها.,"Kepadatan yang dianggap permukaan. Nilai rendah menebalkan gumpalan, nilai tinggi menipiskannya."
+IsBipolar,,両側に描く,Draw Both Sides,双向绘制,雙向繪製,양쪽에 그리기,Dibujar ambos lados,الرسم في الاتجاهين,Gambar Dua Sisi
+IsBipolarDescription,,中心線から上下に伸ばします。波形の符号を活かす場合に使います,Extends upward and downward from the centre line. Use this to keep the sign of a waveform.,从中心线向上下伸展。用于保留波形的符号。,從中心線向上下伸展。用於保留波形的符號。,중심선에서 위아래로 뻗습니다. 파형의 부호를 살릴 때 사용합니다.,Se extiende hacia arriba y hacia abajo desde la línea central. Úselo para conservar el signo de una forma de onda.,يمتد لأعلى ولأسفل من الخط المركزي. استخدمه للحفاظ على إشارة الموجة.,Memanjang ke atas dan ke bawah dari garis tengah. Gunakan untuk mempertahankan tanda gelombang.
+MetaballColor,,色,Colour,颜色,顏色,색,Color,اللون,Warna
+MetaballColorDescription,,塊の色です,Colour of the blobs.,融合球的颜色。,融合球的顏色。,덩어리의 색입니다.,Color de las metabolas.,لون الكرات.,Warna gumpalan.

--- a/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
+++ b/YukkuriMovieMaker.Plugin.Community/YukkuriMovieMaker.Plugin.Community.csproj
@@ -231,6 +231,7 @@
     <Resource Include="$(ShaderDirPath)RadianceCascade.cso" Link="Resources\Shader\RadianceCascade.cso" />
     <Resource Include="$(ShaderDirPath)RadianceComposite.cso" Link="Resources\Shader\RadianceComposite.cso" />
     <Resource Include="$(ShaderDirPath)RadianceOccupancy.cso" Link="Resources\Shader\RadianceOccupancy.cso" />
+    <Resource Include="$(ShaderDirPath)MetaballSpectrum.cso" Link="Resources\Shader\MetaballSpectrum.cso" />
   </ItemGroup>
 
   <!-- テストがinternalsを参照できるかを構成に依存させないため、全構成で付与する。ただし本体側のDEBUG限定テストフックに依存するテストは引き続きDEBUG限定 -->


### PR DESCRIPTION
## チェックリスト
<!-- 確認が完了したら [x] を付けてください -->
- [x] PRの宛先ブランチが正しいことを確認しました
  - 新機能の追加 → **`develop` ブランチ宛**
  - リリース済み機能のバグ修正 → **`master` ブランチ宛**
- [x] このPRには1つの機能（または1つの修正）のみが含まれています
- [x] `YukkuriMovieMaker.dll`などYMM4本体の内部実装アセンブリを参照していません

## 概要
<!-- 変更内容を簡単に記載してください -->

波形に「メタボール」を追加します。
周波数帯ごとに縦長の塊を置き、塊の密度を足し合わせた値がしきい値と等しくなる面を輪郭にします。
隣り合う塊が近づくと密度が重なって橋が架かり、離れると切れます。値が大きい帯ほど塊は高く伸びます。
輪郭は、密度とその勾配から求めた等値面までの距離をもとに滑らかにします。密度の傾きが急な場所でも縁のぼけ幅は変わりません。

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a1c17738-98f5-4c26-8678-02a45c505a2b" />